### PR TITLE
Feature/hzn 73 sp res mtf plot should only plot half values

### DIFF
--- a/hazenlib/spatial_resolution.py
+++ b/hazenlib/spatial_resolution.py
@@ -424,6 +424,10 @@ def calculate_mtf_for_edge(dicom, edge, report_path=False):
     x, y = get_edge_profile_coords(angle, intercept, spacing)
     u, esf = get_esf(edge_arr, y)
     lsf = maivis_deriv(u, esf)
+    lsf = np.array(lsf)
+    n=lsf.size
+    freqs= fftfreq(n)
+    mask = freqs > 0
     mtf = abs(np.fft.fft(lsf))
     norm_mtf = mtf / mtf[0]
     mtf_50 = min([i for i in range(len(norm_mtf) - 1) if norm_mtf[i] >= 0.5 >= norm_mtf[i + 1]])
@@ -461,7 +465,7 @@ def calculate_mtf_for_edge(dicom, edge, report_path=False):
         axes[9].set_title('line spread function')
         axes[9].plot(lsf)
         axes[10].set_title('normalised MTF')
-        axes[10].plot(norm_mtf[60:120])
+        axes[10].plot(freqs[mask],norm_mtf[mask])
         fig.savefig(f'{report_path}_{pe}_{edge}.png')
 
     return res

--- a/hazenlib/spatial_resolution.py
+++ b/hazenlib/spatial_resolution.py
@@ -427,12 +427,12 @@ def calculate_mtf_for_edge(dicom, edge, report_path=False):
     lsf = maivis_deriv(u, esf)
     lsf = np.array(lsf)
     n=lsf.size
-    mask = freqs >= 0
     mtf = abs(np.fft.fft(lsf))
     norm_mtf = mtf / mtf[0]
     mtf_50 = min([i for i in range(len(norm_mtf) - 1) if norm_mtf[i] >= 0.5 >= norm_mtf[i + 1]])
     profile_length = max(y.flatten()) - min(y.flatten())
     freqs= fftfreq(n, profile_length/n)
+    mask = freqs >= 0
     mtf_frequency = 10.0 * mtf_50 / profile_length
     res = 10 / (2 * mtf_frequency)
 

--- a/hazenlib/spatial_resolution.py
+++ b/hazenlib/spatial_resolution.py
@@ -427,12 +427,12 @@ def calculate_mtf_for_edge(dicom, edge, report_path=False):
     lsf = maivis_deriv(u, esf)
     lsf = np.array(lsf)
     n=lsf.size
-    freqs= fftfreq(n)
-    mask = freqs > 0
+    mask = freqs >= 0
     mtf = abs(np.fft.fft(lsf))
     norm_mtf = mtf / mtf[0]
     mtf_50 = min([i for i in range(len(norm_mtf) - 1) if norm_mtf[i] >= 0.5 >= norm_mtf[i + 1]])
     profile_length = max(y.flatten()) - min(y.flatten())
+    freqs= fftfreq(n, profile_length/n)
     mtf_frequency = 10.0 * mtf_50 / profile_length
     res = 10 / (2 * mtf_frequency)
 

--- a/hazenlib/spatial_resolution.py
+++ b/hazenlib/spatial_resolution.py
@@ -461,7 +461,7 @@ def calculate_mtf_for_edge(dicom, edge, report_path=False):
         axes[9].set_title('line spread function')
         axes[9].plot(lsf)
         axes[10].set_title('normalised MTF')
-        axes[10].plot(norm_mtf)
+        axes[10].plot(norm_mtf[60:120])
         fig.savefig(f'{report_path}_{pe}_{edge}.png')
 
     return res

--- a/hazenlib/spatial_resolution.py
+++ b/hazenlib/spatial_resolution.py
@@ -15,6 +15,7 @@ import traceback
 
 import cv2 as cv
 import numpy as np
+from numpy.fft import fftfreq
 
 import hazenlib
 


### PR DESCRIPTION
Original Issue:
 SpRes-MTF plot should only plot half values #73

  Consider only plotting half of the MTF (L465)--the second half is a Nyquist aliasing (I think!) from the FFT.

Upon inspection, the plot of MTF contained both positive and negative frequencies, because that is what the FFT outputs since the basic functions of the fft are complex exponentials. 
It makes sense to only plot the positive frequencies, so I changed how the MTF was plotted.