### PR TITLE
Fix unit tests so failed tests trigger a fail

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -60,7 +60,8 @@ jobs:
 
     - name: Test with pytest
       run: |
-        coverage run -m --source=hazenlib pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered tests/ | tee pytest-coverage.txt
+        set -o pipefail
+        pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=hazenlib tests/ | tee pytest-coverage.txt ; echo $?
 
     - name: Pytest coverage comment
       id: coverageComment

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8 pytest pytest-cov
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: Setup flake8 annotations

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -4,9 +4,6 @@
 name: Tests
 
 on:
-  push:
-    branches:
-      - '*'
   pull_request:
     branches:
       - '*'


### PR DESCRIPTION
Main issue is caused by piping the output of the pytest function to the pytest-coverage.txt file - this pipeing operation completes successfully whether pytest passes or fails so the exist code will always be 1. By first setting `pipefail -o set` then we can reverse the direction of the exit code evaluation so exit codes are a result of the leftmost function in a command.