### PR TITLE
wrote new function to find LSF

### DIFF
--- a/hazenlib/spatial_resolution.py
+++ b/hazenlib/spatial_resolution.py
@@ -71,6 +71,7 @@ def maivis_deriv(x, a, h=1, n=1, axis=-1):
     return b
 
 def deri(a):
+    # This function calculated the LSF by taking the derivative of the ESF. Reference: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3643984/
     b = np.gradient(a)
     return b
 

--- a/hazenlib/spatial_resolution.py
+++ b/hazenlib/spatial_resolution.py
@@ -70,6 +70,9 @@ def maivis_deriv(x, a, h=1, n=1, axis=-1):
     b.extend([b[-1]] * 3)
     return b
 
+def deri(a):
+    b = np.gradient(a)
+    return b
 
 def create_line_iterator(P1, P2, img):
     """
@@ -430,7 +433,7 @@ def calculate_mtf_for_edge(dicom, edge, report_path=False):
     angle, intercept = get_edge_angle_and_intercept(x_edge, y_edge)
     x, y = get_edge_profile_coords(angle, intercept, spacing)
     u, esf = get_esf(edge_arr, y)
-    lsf = maivis_deriv(u, esf)
+    lsf = deri(esf)
     lsf = np.array(lsf)
     n=lsf.size
     mtf = abs(np.fft.fft(lsf))


### PR DESCRIPTION
As mentioned, I could not find the literature to support the Maivis equation which finds the LSF. However it seems the LSF can be simply calculated by taking the derivative of the ESF http://sciencewise.info/resource/line_spread_function/Line_spread_function_by_Wikipedia. So I changed the function directly. Let me know if this fix is ok. 
The calculate_mtf_test is not failing but I think it's because the output will be different with the new function I added.

I attach a picture to show the difference in the appearance of the MTF 
<img width="556" alt="maivis_vs_deriv" src="https://user-images.githubusercontent.com/83493021/143399493-9595d4b8-db7e-4d63-b750-2b877046fef7.png">


In this paper https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3643984/ they also claim they find LSF from differentiation of ESF, which supports this new change of function.