### PR TITLE
Update coverage badge on commit to main

### DIFF
--- a/.github/workflows/tests_development.yml
+++ b/.github/workflows/tests_development.yml
@@ -66,15 +66,3 @@ jobs:
       with:
         pytest-coverage-path: ./pytest-coverage.txt
         junitxml-path: ./pytest.xml
-
-    - name: Update the coverage Badge
-      if: github.event.pull_request.base.ref == 'master'  # if pull request is merging into master
-      uses: schneegans/dynamic-badges-action@v1.0.0
-      with:
-        auth: ${{ secrets.PYTEST_COVERAGE_COMMENT }}
-        gistID: ba102d5f3e592fcd50451c2eff8a803d
-        filename: hazen_pytest-coverage-comment.json
-        label: Test coverage
-        message: ${{ steps.coverageComment.outputs.coverage }}
-        color: ${{ steps.coverageComment.outputs.color }}
-        namedLogo: python

--- a/.github/workflows/tests_development.yml
+++ b/.github/workflows/tests_development.yml
@@ -66,3 +66,15 @@ jobs:
       with:
         pytest-coverage-path: ./pytest-coverage.txt
         junitxml-path: ./pytest.xml
+
+    - name: Update the coverage Badge
+      if: github.event.pull_request.base.ref == 'main'  # if pull request is merging into master
+      uses: schneegans/dynamic-badges-action@v1.0.0
+      with:
+        auth: ${{ secrets.PYTEST_COVERAGE_COMMENT }}
+        gistID: ba102d5f3e592fcd50451c2eff8a803d
+        filename: hazen_pytest-coverage-comment.json
+        label: Test coverage
+        message: ${{ steps.coverageComment.outputs.coverage }}
+        color: ${{ steps.coverageComment.outputs.color }}
+        namedLogo: python

--- a/.github/workflows/tests_release.yml
+++ b/.github/workflows/tests_release.yml
@@ -51,13 +51,6 @@ jobs:
         set -o pipefail
         pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=hazenlib tests/ | tee pytest-coverage.txt ; echo $?
 
-    - name: Pytest coverage comment
-      id: coverageComment
-      uses: MishaKav/pytest-coverage-comment@main
-      with:
-        pytest-coverage-path: ./pytest-coverage.txt
-        junitxml-path: ./pytest.xml
-
     - name: Update the coverage Badge
       if: ${GITHUB_REF##*/} == 'main'  # if commit is on main branch
       uses: schneegans/dynamic-badges-action@v1.0.0

--- a/.github/workflows/tests_release.yml
+++ b/.github/workflows/tests_release.yml
@@ -50,15 +50,3 @@ jobs:
       run: |
         set -o pipefail
         pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=hazenlib tests/ | tee pytest-coverage.txt ; echo $?
-
-    - name: Update the coverage Badge
-      if: ${GITHUB_REF##*/} == 'main'  # if commit is on main branch
-      uses: schneegans/dynamic-badges-action@v1.0.0
-      with:
-        auth: ${{ secrets.PYTEST_COVERAGE_COMMENT }}
-        gistID: ba102d5f3e592fcd50451c2eff8a803d
-        filename: hazen_pytest-coverage-comment.json
-        label: Test coverage
-        message: ${{ steps.coverageComment.outputs.coverage }}
-        color: ${{ steps.coverageComment.outputs.color }}
-        namedLogo: python

--- a/.github/workflows/tests_release.yml
+++ b/.github/workflows/tests_release.yml
@@ -51,3 +51,21 @@ jobs:
         set -o pipefail
         pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=hazenlib tests/ | tee pytest-coverage.txt ; echo $?
 
+    - name: Pytest coverage comment
+      id: coverageComment
+      uses: MishaKav/pytest-coverage-comment@main
+      with:
+        pytest-coverage-path: ./pytest-coverage.txt
+        junitxml-path: ./pytest.xml
+
+    - name: Update the coverage Badge
+      if: ${GITHUB_REF##*/} == 'main'  # if commit is on main branch
+      uses: schneegans/dynamic-badges-action@v1.0.0
+      with:
+        auth: ${{ secrets.PYTEST_COVERAGE_COMMENT }}
+        gistID: ba102d5f3e592fcd50451c2eff8a803d
+        filename: hazen_pytest-coverage-comment.json
+        label: Test coverage
+        message: ${{ steps.coverageComment.outputs.coverage }}
+        color: ${{ steps.coverageComment.outputs.color }}
+        namedLogo: python


### PR DESCRIPTION
Current workflow doesn't update the coverage badge, leaving it blank. 

New workflow will update badge on a pull request which merges into a branch called 'main'