### PR TITLE
Update Dockerfile to allow uid/gid specification depending on host OS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,32 @@
 FROM python:3.9
 RUN apt-get update
 RUN apt-get install ffmpeg libsm6 libxext6 -y
-RUN groupadd -r hazen_user && useradd --create-home --shell /bin/bash -r -g hazen_user hazen_user
-COPY . /home/hazen_user/hazen
-WORKDIR /home/hazen_user/hazen
+
+# Enable Adjustable Permissions
+# Note: these values can be overridden during docker build, e.g.:
+# docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -f Dockerfile -t hazen_test_img .
+ARG UNAME=hazen_user
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g $GID -o $UNAME
+RUN useradd -m -u $UID -g $GID --create-home --shell /bin/bash -r $UNAME
+
+COPY . /home/$UNAME/hazen
+
+# Python Install
+WORKDIR /home/$UNAME/hazen
 RUN pip install --upgrade pip
 RUN pip install --no-cache-dir -r requirements.txt
 RUN python setup.py install
-USER hazen_user
-WORKDIR ../data
+
+# Final Setup
+WORKDIR /home/$UNAME/data
+USER $UNAME
 ENTRYPOINT ["hazen"]
 
 # docker build -t docker_hazen .
 ## run interactive
 # docker run -it --rm --name hazen --mount type=bind,source="$(pwd)",target=/home/hazen_user/data docker_hazen /bin/bash
-#docker run -it --entrypoint /bin/bash --mount type=bind,source="$(pwd)",target=/home/hazen_user/data gsttmriphysics/hazen
+# docker run -it --entrypoint /bin/bash --mount type=bind,source="$(pwd)",target=/home/hazen_user/data gsttmriphysics/hazen
 ## run normal
 # docker run --rm --mount type=bind,source="$(pwd)",target=/home/hazen_user/data -w /home/hazen_user/data docker_hazen


### PR DESCRIPTION
hazen-app is not working properly on Linux or WSL2. The Docker container is successfully pulled, but running any commands which write files results in permission errors causing hazen-app to fail.

Further investigation revealed that the default UID and GID of the hazen Docker container is different to the host UID/GID. On MacOS, this is not a problem (will eventually look into why).

This PR updates the Dockerfile to enable the UID/GID to be changed. By default, they are set to `1000` in the Dockerfile which corresponds to the default WSL2 UID/GID.

To override the UID/GID values the UID/GID values on the host can be fetched and sent to `docker build`, e.g.:

`docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -f Dockerfile -t hazen_test_img .`

So far built locally on WSL2 and Ubuntu using: `docker run -it -v "$(pwd)":/home/hazen_user/data hazen_test_img:latest snr tests/data/snr/Siemens/`

[See this Stackoverflow thread for bit more info.](https://stackoverflow.com/questions/44683119/dockerfile-replicate-the-host-user-uid-and-gid-to-the-image)

@laurencejackson – need to think about how to fit this in with the rest of hazen. I'm thinking about the automation scripts for uploading Releases to Dockerhub.
