### PR TITLE
Updated ghosting function – fixes sampling point issue

### DIFF
--- a/hazenlib/ghosting.py
+++ b/hazenlib/ghosting.py
@@ -211,7 +211,7 @@ def get_ghosting(dcm, report_path=False) -> dict:
 
     ghosting = calculate_ghost_intensity(ghost, phantom, noise)
 
-    if report_path:
+    if report_path == True:
         import matplotlib.pyplot as plt
         fig, ax = plt.subplots()
         x1, x2, y1, y2 = bbox

--- a/hazenlib/ghosting.py
+++ b/hazenlib/ghosting.py
@@ -169,7 +169,7 @@ def get_eligible_area(signal_bounding_box, dcm, slice_radius=5):
 
 
 
-def get_ghost_slice2(signal_bounding_box, dcm, slice_radius=5):
+def get_ghost_slice(signal_bounding_box, dcm, slice_radius=5):
     eligible_area = get_eligible_area(signal_bounding_box, dcm, slice_radius=slice_radius)
     ghost_slice = np.array(
         range(min(eligible_area[1]),max(eligible_area[1])), dtype=np.intp)[:, np.newaxis], np.array(
@@ -195,7 +195,7 @@ def get_ghosting(dcm, report_path=False) -> dict:
 
     signal_centre = [(bbox[0]+bbox[1])//2, (bbox[2]+bbox[3])//2]
     background_rois = get_background_rois(dcm, signal_centre)
-    ghost_col, ghost_row = get_ghost_slice2(bbox, dcm, slice_radius=slice_radius)
+    ghost_col, ghost_row = get_ghost_slice(bbox, dcm, slice_radius=slice_radius)
     ghost = dcm.pixel_array[(ghost_col, ghost_row)]
     signal_col, signal_row = get_signal_slice(bbox, slice_radius=slice_radius)
     phantom = dcm.pixel_array[(signal_row, signal_col)]

--- a/hazenlib/ghosting.py
+++ b/hazenlib/ghosting.py
@@ -33,7 +33,7 @@ def calculate_ghost_intensity(ghost, phantom, noise) -> float:
     if phantom_mean < ghost_mean or phantom_mean < noise_mean:
         raise Exception(f"The mean phantom signal is lower than the ghost or the noise signal. This can't be the case ")
 
-    return 100 * (ghost_mean - noise_mean) / phantom_mean
+    return 100 * abs((ghost_mean - noise_mean)) / phantom_mean
 
 
 def get_signal_bounding_box(array: np.ndarray):
@@ -202,7 +202,7 @@ def get_ghosting(dcm, report_path=False) -> dict:
 
 
 
-    noise = np.concatenate([dcm.pixel_array[(row, col)] for col, row in get_background_slices(background_rois, slice_radius=30)])
+    noise = np.concatenate([dcm.pixel_array[(row, col)] for col, row in get_background_slices(background_rois, slice_radius=slice_radius)])
 
 
 
@@ -278,4 +278,5 @@ def main(data: list, report_path = False) -> dict:
 
 if __name__ == "__main__":
     main([os.path.join(sys.argv[1], i) for i in os.listdir(sys.argv[1])])
+
 

--- a/tests/test_ghosting.py
+++ b/tests/test_ghosting.py
@@ -18,14 +18,18 @@ class TestGhosting(unittest.TestCase):
     ELIGIBLE_GHOST_AREA = range(5, SIGNAL_BOUNDING_BOX[0] - PADDING_FROM_BOX), range(
         SIGNAL_BOUNDING_BOX[2], SIGNAL_BOUNDING_BOX[3])
 
+
     SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS,
                                   SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[:, np.newaxis], np.array(
         range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS), dtype=np.intp)
 
-    GHOST_SLICE = np.array(range(13 - SLICE_RADIUS, 13 + SLICE_RADIUS), dtype=np.intp)[:, np.newaxis], np.array(
-        range(283 - SLICE_RADIUS, 283 + SLICE_RADIUS)
+    GHOST_SLICE = np.array(
+        range(min(ELIGIBLE_GHOST_AREA[1]), max(ELIGIBLE_GHOST_AREA[1])), dtype=np.intp)[:, np.newaxis], np.array(
+        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0]))
     )
-    GHOSTING = (None, 0.6115742783493184)
+
+
+    GHOSTING = (None,  0.11803264099090763)
 
     def setUp(self):
         self.file = str(TEST_DATA_DIR / 'ghosting' / 'GHOSTING' / 'IM_0001.dcm')
@@ -40,16 +44,18 @@ class TestGhosting(unittest.TestCase):
 
         with pytest.raises(Exception):
             hazen_ghosting.calculate_ghost_intensity(ghost=np.asarray([-10]),
-                                                     phantom=np.asarray([-100]),
-                                                     noise=np.asarray([-5]))
+             phantom=np.asarray([-100]),
+         noise=np.asarray([-5]))
 
         assert 5.0 == hazen_ghosting.calculate_ghost_intensity(ghost=np.asarray([10]),
-                                                               phantom=np.asarray([100]),
-                                                               noise=np.asarray([5]))
+                                               phantom=np.asarray([100]),
+                                        noise=np.asarray([5]))
 
-        assert -5.0 == hazen_ghosting.calculate_ghost_intensity(ghost=np.asarray([5]),
-                                                                phantom=np.asarray([100]),
-                                                                noise=np.asarray([10]))
+            # assert -5.0 == hazen_ghosting.calculate_ghost_intensity(ghost=np.asarray([5]),
+            #                    phantom=np.asarray([100]),
+        #                   noise=np.asarray([10]))
+
+
 
     def test_get_signal_bounding_box(self):
         (left_column, right_column, upper_row, lower_row,) = hazen_ghosting.get_signal_bounding_box(
@@ -79,44 +85,57 @@ class TestGhosting(unittest.TestCase):
 
 
 class TestCOLPEGhosting(TestGhosting):
-    SIGNAL_BOUNDING_BOX = (164, 208, 166, 209)
-    SIGNAL_CENTRE = [186, 187]
-    BACKGROUND_ROIS = [(64, 187), (64, 140), (64, 93), (64, 46)]
-    PADDING_FROM_BOX = 30
-    SLICE_RADIUS = 5
-    ELIGIBLE_GHOST_AREA = range(SIGNAL_BOUNDING_BOX[0], SIGNAL_BOUNDING_BOX[1]), range(
-        SLICE_RADIUS, SIGNAL_BOUNDING_BOX[2] - PADDING_FROM_BOX)
+        SIGNAL_BOUNDING_BOX = (164, 208, 166, 209)
+        SIGNAL_CENTRE = [186, 187]
+        BACKGROUND_ROIS = [(64, 187), (64, 140), (64, 93), (64, 46)]
+        PADDING_FROM_BOX = 30
+        SLICE_RADIUS = 5
+        ELIGIBLE_GHOST_AREA = range(SIGNAL_BOUNDING_BOX[0], SIGNAL_BOUNDING_BOX[1]), range(
+            SLICE_RADIUS, SIGNAL_BOUNDING_BOX[2] - PADDING_FROM_BOX)
 
-    SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[:,
-                   np.newaxis], np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),
-                                         dtype=np.intp)
-    GHOST_SLICE = np.array(range(197 - SLICE_RADIUS, 197 + SLICE_RADIUS), dtype=np.intp)[:, np.newaxis], np.array(
-        range(135 - SLICE_RADIUS, 135 + SLICE_RADIUS))
-    PE = "COL"
-    GHOSTING = (None, 0.317544586211758)
+        SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[
+                       :,
+                       np.newaxis], np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),
+                                             dtype=np.intp)
+        GHOST_SLICE = np.array(
+        range(min(ELIGIBLE_GHOST_AREA[1]), max(ELIGIBLE_GHOST_AREA[1])), dtype=np.intp)[:, np.newaxis], np.array(
+        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0]))
+    )
+        PE = "COL"
+        GHOSTING = (None,  0.015138960417776908)
 
-    def setUp(self):
-        self.file = str(TEST_DATA_DIR / 'ghosting' / 'PE_COL_PHANTOM_BOTTOM_RIGHT' / 'PE_COL_PHANTOM_BOTTOM_RIGHT.IMA')
-        self.dcm = pydicom.read_file(self.file)
+        def setUp(self):
+            self.file = str(
+                TEST_DATA_DIR / 'ghosting' / 'PE_COL_PHANTOM_BOTTOM_RIGHT' / 'PE_COL_PHANTOM_BOTTOM_RIGHT.IMA')
+            self.dcm = pydicom.read_file(self.file)
 
 
 class TestAxialPhilipsBroomfields(TestGhosting):
-    SIGNAL_BOUNDING_BOX = (217, 299, 11, 93)
-    SIGNAL_CENTRE = [(SIGNAL_BOUNDING_BOX[0] + SIGNAL_BOUNDING_BOX[1]) // 2,
-                     (SIGNAL_BOUNDING_BOX[2] + SIGNAL_BOUNDING_BOX[3]) // 2]
-    BACKGROUND_ROIS = [(258, 264), (194, 264), (130, 264), (66, 264)]
-    PADDING_FROM_BOX = 30
-    SLICE_RADIUS = 5
-    ELIGIBLE_GHOST_AREA = range(SLICE_RADIUS, SIGNAL_BOUNDING_BOX[0] - PADDING_FROM_BOX), range(
-        SIGNAL_BOUNDING_BOX[2], SIGNAL_BOUNDING_BOX[3])
-    SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[:,
-                   np.newaxis], np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),
-                                         dtype=np.intp)
-    GHOST_SLICE = np.array(range(11 - SLICE_RADIUS, 11 + SLICE_RADIUS), dtype=np.intp)[:, np.newaxis], np.array(
-        range(16 - SLICE_RADIUS, 16 + SLICE_RADIUS))
+        SIGNAL_BOUNDING_BOX = (217, 299, 11, 93)
+        SIGNAL_CENTRE = [(SIGNAL_BOUNDING_BOX[0] + SIGNAL_BOUNDING_BOX[1]) // 2,
+                         (SIGNAL_BOUNDING_BOX[2] + SIGNAL_BOUNDING_BOX[3]) // 2]
+        BACKGROUND_ROIS = [(258, 264), (194, 264), (130, 264), (66, 264)]
+        PADDING_FROM_BOX = 30
+        SLICE_RADIUS = 5
+        ELIGIBLE_GHOST_AREA = range(SLICE_RADIUS, SIGNAL_BOUNDING_BOX[0] - PADDING_FROM_BOX), range(
+            SIGNAL_BOUNDING_BOX[2], SIGNAL_BOUNDING_BOX[3])
+        SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[
+                       :,
+                       np.newaxis], np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),
+                                             dtype=np.intp)
+        GHOST_SLICE = np.array(
+        range(min(ELIGIBLE_GHOST_AREA[1]), max(ELIGIBLE_GHOST_AREA[1])), dtype=np.intp)[:, np.newaxis], np.array(
+        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0]))
+    )
 
-    GHOSTING = (None, 0.6244366401836245)
+        GHOSTING = (None,  0.007246960909896829)
 
-    def setUp(self):
-        self.file = str(TEST_DATA_DIR / 'ghosting' / 'GHOSTING' / 'axial_philips_broomfields.dcm')
-        self.dcm = pydicom.read_file(self.file)
+        def setUp(self):
+            self.file = str(TEST_DATA_DIR / 'ghosting' / 'GHOSTING' / 'axial_philips_broomfields.dcm')
+            self.dcm = pydicom.read_file(self.file)
+
+
+
+
+
+

--- a/tests/test_ghosting.py
+++ b/tests/test_ghosting.py
@@ -47,10 +47,6 @@ class TestGhosting(unittest.TestCase):
                                                                phantom=np.asarray([100]),
                                                                noise=np.asarray([5]))
 
-            # assert -5.0 == hazen_ghosting.calculate_ghost_intensity(ghost=np.asarray([5]),
-            #                    phantom=np.asarray([100]),
-        #                   noise=np.asarray([10]))
-
 
 
     def test_get_signal_bounding_box(self):

--- a/tests/test_ghosting.py
+++ b/tests/test_ghosting.py
@@ -4,7 +4,7 @@ import numpy as np
 import pydicom
 import pytest
 
-import hazenlib.test_g as hazen_ghosting
+import hazenlib.ghosting as hazen_ghosting
 from tests import TEST_DATA_DIR
 
 

--- a/tests/test_ghosting.py
+++ b/tests/test_ghosting.py
@@ -51,11 +51,6 @@ class TestGhosting(unittest.TestCase):
                                                phantom=np.asarray([100]),
                                         noise=np.asarray([5]))
 
-            # assert -5.0 == hazen_ghosting.calculate_ghost_intensity(ghost=np.asarray([5]),
-            #                    phantom=np.asarray([100]),
-        #                   noise=np.asarray([10]))
-
-
 
     def test_get_signal_bounding_box(self):
         (left_column, right_column, upper_row, lower_row,) = hazen_ghosting.get_signal_bounding_box(

--- a/tests/test_ghosting.py
+++ b/tests/test_ghosting.py
@@ -8,7 +8,6 @@ import hazenlib.ghosting as hazen_ghosting
 from tests import TEST_DATA_DIR
 
 
-
 class TestGhosting(unittest.TestCase):
     SIGNAL_BOUNDING_BOX = (252, 334, 243, 325)
     SIGNAL_CENTRE = [293, 284]
@@ -48,6 +47,11 @@ class TestGhosting(unittest.TestCase):
                                                                phantom=np.asarray([100]),
                                                                noise=np.asarray([5]))
 
+            # assert -5.0 == hazen_ghosting.calculate_ghost_intensity(ghost=np.asarray([5]),
+            #                    phantom=np.asarray([100]),
+        #                   noise=np.asarray([10]))
+
+
 
     def test_get_signal_bounding_box(self):
         (left_column, right_column, upper_row, lower_row,) = hazen_ghosting.get_signal_bounding_box(self.dcm.pixel_array)
@@ -75,47 +79,47 @@ class TestGhosting(unittest.TestCase):
 
 
 class TestCOLPEGhosting(TestGhosting):
-        SIGNAL_BOUNDING_BOX = (164, 208, 166, 209)
-        SIGNAL_CENTRE = [186, 187]
-        BACKGROUND_ROIS = [(64, 187), (64, 140), (64, 93), (64, 46)]
-        PADDING_FROM_BOX = 30
-        SLICE_RADIUS = 5
-        ELIGIBLE_GHOST_AREA = range(SIGNAL_BOUNDING_BOX[0], SIGNAL_BOUNDING_BOX[1]), range(
-            SLICE_RADIUS, SIGNAL_BOUNDING_BOX[2] - PADDING_FROM_BOX)
+    SIGNAL_BOUNDING_BOX = (164, 208, 166, 209)
+    SIGNAL_CENTRE = [186, 187]
+    BACKGROUND_ROIS = [(64, 187), (64, 140), (64, 93), (64, 46)]
+    PADDING_FROM_BOX = 30
+    SLICE_RADIUS = 5
+    ELIGIBLE_GHOST_AREA = range(SIGNAL_BOUNDING_BOX[0], SIGNAL_BOUNDING_BOX[1]), range(
+                          SLICE_RADIUS, SIGNAL_BOUNDING_BOX[2] - PADDING_FROM_BOX)
 
-        SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[:,np.newaxis],\
+    SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[:,np.newaxis],\
                        np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),dtype=np.intp)
 
-        GHOST_SLICE = np.array(
+    GHOST_SLICE = np.array(
         range(min(ELIGIBLE_GHOST_AREA[1]), max(ELIGIBLE_GHOST_AREA[1])), dtype=np.intp)[:, np.newaxis], np.array(
         range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0])))
 
-        PE = "COL"
-        GHOSTING = (None,  0.015138960417776908)
+    PE = "COL"
+    GHOSTING = (None,  0.015138960417776908)
 
-        def setUp(self):
+    def setUp(self):
             self.file = str(TEST_DATA_DIR / 'ghosting' / 'PE_COL_PHANTOM_BOTTOM_RIGHT' / 'PE_COL_PHANTOM_BOTTOM_RIGHT.IMA')
             self.dcm = pydicom.read_file(self.file)
 
 
 class TestAxialPhilipsBroomfields(TestGhosting):
-        SIGNAL_BOUNDING_BOX = (217, 299, 11, 93)
-        SIGNAL_CENTRE = [(SIGNAL_BOUNDING_BOX[0] + SIGNAL_BOUNDING_BOX[1]) // 2,
+    SIGNAL_BOUNDING_BOX = (217, 299, 11, 93)
+    SIGNAL_CENTRE = [(SIGNAL_BOUNDING_BOX[0] + SIGNAL_BOUNDING_BOX[1]) // 2,
                          (SIGNAL_BOUNDING_BOX[2] + SIGNAL_BOUNDING_BOX[3]) // 2]
-        BACKGROUND_ROIS = [(258, 264), (194, 264), (130, 264), (66, 264)]
-        PADDING_FROM_BOX = 30
-        SLICE_RADIUS = 5
-        ELIGIBLE_GHOST_AREA = range(SLICE_RADIUS, SIGNAL_BOUNDING_BOX[0] - PADDING_FROM_BOX), range(
+    BACKGROUND_ROIS = [(258, 264), (194, 264), (130, 264), (66, 264)]
+    PADDING_FROM_BOX = 30
+    SLICE_RADIUS = 5
+    ELIGIBLE_GHOST_AREA = range(SLICE_RADIUS, SIGNAL_BOUNDING_BOX[0] - PADDING_FROM_BOX), range(
             SIGNAL_BOUNDING_BOX[2], SIGNAL_BOUNDING_BOX[3])
-        SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[:,np.newaxis],\
+    SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[:,np.newaxis],\
                        np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),dtype=np.intp)
-        GHOST_SLICE = np.array(
+    GHOST_SLICE = np.array(
         range(min(ELIGIBLE_GHOST_AREA[1]), max(ELIGIBLE_GHOST_AREA[1])), dtype=np.intp)[:, np.newaxis], np.array(
         range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0])))
 
-        GHOSTING = (None,  0.007246960909896829)
+    GHOSTING = (None,  0.007246960909896829)
 
-        def setUp(self):
+    def setUp(self):
             self.file = str(TEST_DATA_DIR / 'ghosting' / 'GHOSTING' / 'axial_philips_broomfields.dcm')
             self.dcm = pydicom.read_file(self.file)
 

--- a/tests/test_ghosting.py
+++ b/tests/test_ghosting.py
@@ -8,6 +8,7 @@ import hazenlib.ghosting as hazen_ghosting
 from tests import TEST_DATA_DIR
 
 
+
 class TestGhosting(unittest.TestCase):
     SIGNAL_BOUNDING_BOX = (252, 334, 243, 325)
     SIGNAL_CENTRE = [293, 284]
@@ -15,19 +16,14 @@ class TestGhosting(unittest.TestCase):
     PADDING_FROM_BOX = 30
     SLICE_RADIUS = 5
     PE = 'ROW'
-    ELIGIBLE_GHOST_AREA = range(5, SIGNAL_BOUNDING_BOX[0] - PADDING_FROM_BOX), range(
-        SIGNAL_BOUNDING_BOX[2], SIGNAL_BOUNDING_BOX[3])
+    ELIGIBLE_GHOST_AREA = range(5, SIGNAL_BOUNDING_BOX[0] - PADDING_FROM_BOX), range(SIGNAL_BOUNDING_BOX[2], SIGNAL_BOUNDING_BOX[3])
 
-
-    SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS,
-                                  SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[:, np.newaxis], np.array(
-        range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS), dtype=np.intp)
+    SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[:, np.newaxis], np.array(
+                   range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS), dtype=np.intp)
 
     GHOST_SLICE = np.array(
         range(min(ELIGIBLE_GHOST_AREA[1]), max(ELIGIBLE_GHOST_AREA[1])), dtype=np.intp)[:, np.newaxis], np.array(
-        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0]))
-    )
-
+        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0])))
 
     GHOSTING = (None,  0.11803264099090763)
 
@@ -45,23 +41,16 @@ class TestGhosting(unittest.TestCase):
 
         with pytest.raises(Exception):
             hazen_ghosting.calculate_ghost_intensity(ghost=np.asarray([-10]),
-             phantom=np.asarray([-100]),
-         noise=np.asarray([-5]))
+                                                     phantom=np.asarray([-100]),
+                                                     noise=np.asarray([-5]))
 
         assert 5.0 == hazen_ghosting.calculate_ghost_intensity(ghost=np.asarray([10]),
-                                               phantom=np.asarray([100]),
-                                        noise=np.asarray([5]))
-
-            # assert -5.0 == hazen_ghosting.calculate_ghost_intensity(ghost=np.asarray([5]),
-            #                    phantom=np.asarray([100]),
-        #                   noise=np.asarray([10]))
-
+                                                               phantom=np.asarray([100]),
+                                                               noise=np.asarray([5]))
 
 
     def test_get_signal_bounding_box(self):
-        (left_column, right_column, upper_row, lower_row,) = hazen_ghosting.get_signal_bounding_box(
-            self.dcm.pixel_array)
-
+        (left_column, right_column, upper_row, lower_row,) = hazen_ghosting.get_signal_bounding_box(self.dcm.pixel_array)
         assert (left_column, right_column, upper_row, lower_row) == self.SIGNAL_BOUNDING_BOX
 
     def test_get_signal_slice(self):
@@ -94,20 +83,18 @@ class TestCOLPEGhosting(TestGhosting):
         ELIGIBLE_GHOST_AREA = range(SIGNAL_BOUNDING_BOX[0], SIGNAL_BOUNDING_BOX[1]), range(
             SLICE_RADIUS, SIGNAL_BOUNDING_BOX[2] - PADDING_FROM_BOX)
 
-        SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[
-                       :,
-                       np.newaxis], np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),
-                                             dtype=np.intp)
+        SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[:,np.newaxis],\
+                       np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),dtype=np.intp)
+
         GHOST_SLICE = np.array(
         range(min(ELIGIBLE_GHOST_AREA[1]), max(ELIGIBLE_GHOST_AREA[1])), dtype=np.intp)[:, np.newaxis], np.array(
-        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0]))
-    )
+        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0])))
+
         PE = "COL"
         GHOSTING = (None,  0.015138960417776908)
 
         def setUp(self):
-            self.file = str(
-                TEST_DATA_DIR / 'ghosting' / 'PE_COL_PHANTOM_BOTTOM_RIGHT' / 'PE_COL_PHANTOM_BOTTOM_RIGHT.IMA')
+            self.file = str(TEST_DATA_DIR / 'ghosting' / 'PE_COL_PHANTOM_BOTTOM_RIGHT' / 'PE_COL_PHANTOM_BOTTOM_RIGHT.IMA')
             self.dcm = pydicom.read_file(self.file)
 
 
@@ -120,14 +107,11 @@ class TestAxialPhilipsBroomfields(TestGhosting):
         SLICE_RADIUS = 5
         ELIGIBLE_GHOST_AREA = range(SLICE_RADIUS, SIGNAL_BOUNDING_BOX[0] - PADDING_FROM_BOX), range(
             SIGNAL_BOUNDING_BOX[2], SIGNAL_BOUNDING_BOX[3])
-        SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[
-                       :,
-                       np.newaxis], np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),
-                                             dtype=np.intp)
+        SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[:,np.newaxis],\
+                       np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),dtype=np.intp)
         GHOST_SLICE = np.array(
         range(min(ELIGIBLE_GHOST_AREA[1]), max(ELIGIBLE_GHOST_AREA[1])), dtype=np.intp)[:, np.newaxis], np.array(
-        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0]))
-    )
+        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0])))
 
         GHOSTING = (None,  0.007246960909896829)
 

--- a/tests/test_ghosting.py
+++ b/tests/test_ghosting.py
@@ -4,7 +4,7 @@ import numpy as np
 import pydicom
 import pytest
 
-import hazenlib.ghosting as hazen_ghosting
+import hazenlib.test_g as hazen_ghosting
 from tests import TEST_DATA_DIR
 
 
@@ -28,7 +28,9 @@ class TestGhosting(unittest.TestCase):
         range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0]))
     )
 
+
     GHOSTING = (None,  0.11803264099090763)
+
 
     def setUp(self):
         self.file = str(TEST_DATA_DIR / 'ghosting' / 'GHOSTING' / 'IM_0001.dcm')
@@ -49,6 +51,11 @@ class TestGhosting(unittest.TestCase):
         assert 5.0 == hazen_ghosting.calculate_ghost_intensity(ghost=np.asarray([10]),
                                                phantom=np.asarray([100]),
                                         noise=np.asarray([5]))
+
+            # assert -5.0 == hazen_ghosting.calculate_ghost_intensity(ghost=np.asarray([5]),
+            #                    phantom=np.asarray([100]),
+        #                   noise=np.asarray([10]))
+
 
 
     def test_get_signal_bounding_box(self):
@@ -84,15 +91,17 @@ class TestCOLPEGhosting(TestGhosting):
         BACKGROUND_ROIS = [(64, 187), (64, 140), (64, 93), (64, 46)]
         PADDING_FROM_BOX = 30
         SLICE_RADIUS = 5
-        ELIGIBLE_GHOST_AREA = range(SIGNAL_BOUNDING_BOX[0], SIGNAL_BOUNDING_BOX[1]), range(SLICE_RADIUS, SIGNAL_BOUNDING_BOX[2] - PADDING_FROM_BOX)
+        ELIGIBLE_GHOST_AREA = range(SIGNAL_BOUNDING_BOX[0], SIGNAL_BOUNDING_BOX[1]), range(
+            SLICE_RADIUS, SIGNAL_BOUNDING_BOX[2] - PADDING_FROM_BOX)
 
-       SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[:,np.newaxis], 
-                      np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),dtype=np.intp)
-        
+        SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[
+                       :,
+                       np.newaxis], np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),
+                                             dtype=np.intp)
         GHOST_SLICE = np.array(
         range(min(ELIGIBLE_GHOST_AREA[1]), max(ELIGIBLE_GHOST_AREA[1])), dtype=np.intp)[:, np.newaxis], np.array(
-        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0])))
-        
+        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0]))
+    )
         PE = "COL"
         GHOSTING = (None,  0.015138960417776908)
 
@@ -111,18 +120,22 @@ class TestAxialPhilipsBroomfields(TestGhosting):
         SLICE_RADIUS = 5
         ELIGIBLE_GHOST_AREA = range(SLICE_RADIUS, SIGNAL_BOUNDING_BOX[0] - PADDING_FROM_BOX), range(
             SIGNAL_BOUNDING_BOX[2], SIGNAL_BOUNDING_BOX[3])
-        SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[:,np.newaxis],
-                       np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),dtype=np.intp)
-            
+        SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[
+                       :,
+                       np.newaxis], np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),
+                                             dtype=np.intp)
         GHOST_SLICE = np.array(
         range(min(ELIGIBLE_GHOST_AREA[1]), max(ELIGIBLE_GHOST_AREA[1])), dtype=np.intp)[:, np.newaxis], np.array(
-        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0])))
+        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0]))
+    )
 
         GHOSTING = (None,  0.007246960909896829)
 
         def setUp(self):
             self.file = str(TEST_DATA_DIR / 'ghosting' / 'GHOSTING' / 'axial_philips_broomfields.dcm')
             self.dcm = pydicom.read_file(self.file)
+
+
 
 
 

--- a/tests/test_ghosting.py
+++ b/tests/test_ghosting.py
@@ -28,7 +28,6 @@ class TestGhosting(unittest.TestCase):
         range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0]))
     )
 
-
     GHOSTING = (None,  0.11803264099090763)
 
     def setUp(self):
@@ -85,17 +84,15 @@ class TestCOLPEGhosting(TestGhosting):
         BACKGROUND_ROIS = [(64, 187), (64, 140), (64, 93), (64, 46)]
         PADDING_FROM_BOX = 30
         SLICE_RADIUS = 5
-        ELIGIBLE_GHOST_AREA = range(SIGNAL_BOUNDING_BOX[0], SIGNAL_BOUNDING_BOX[1]), range(
-            SLICE_RADIUS, SIGNAL_BOUNDING_BOX[2] - PADDING_FROM_BOX)
+        ELIGIBLE_GHOST_AREA = range(SIGNAL_BOUNDING_BOX[0], SIGNAL_BOUNDING_BOX[1]), range(SLICE_RADIUS, SIGNAL_BOUNDING_BOX[2] - PADDING_FROM_BOX)
 
-        SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[
-                       :,
-                       np.newaxis], np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),
-                                             dtype=np.intp)
+       SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[:,np.newaxis], 
+                      np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),dtype=np.intp)
+        
         GHOST_SLICE = np.array(
         range(min(ELIGIBLE_GHOST_AREA[1]), max(ELIGIBLE_GHOST_AREA[1])), dtype=np.intp)[:, np.newaxis], np.array(
-        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0]))
-    )
+        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0])))
+        
         PE = "COL"
         GHOSTING = (None,  0.015138960417776908)
 
@@ -114,14 +111,12 @@ class TestAxialPhilipsBroomfields(TestGhosting):
         SLICE_RADIUS = 5
         ELIGIBLE_GHOST_AREA = range(SLICE_RADIUS, SIGNAL_BOUNDING_BOX[0] - PADDING_FROM_BOX), range(
             SIGNAL_BOUNDING_BOX[2], SIGNAL_BOUNDING_BOX[3])
-        SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[
-                       :,
-                       np.newaxis], np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),
-                                             dtype=np.intp)
+        SIGNAL_SLICE = np.array(range(SIGNAL_CENTRE[0] - SLICE_RADIUS, SIGNAL_CENTRE[0] + SLICE_RADIUS), dtype=np.intp)[:,np.newaxis],
+                       np.array(range(SIGNAL_CENTRE[1] - SLICE_RADIUS, SIGNAL_CENTRE[1] + SLICE_RADIUS),dtype=np.intp)
+            
         GHOST_SLICE = np.array(
         range(min(ELIGIBLE_GHOST_AREA[1]), max(ELIGIBLE_GHOST_AREA[1])), dtype=np.intp)[:, np.newaxis], np.array(
-        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0]))
-    )
+        range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0])))
 
         GHOSTING = (None,  0.007246960909896829)
 


### PR DESCRIPTION
Hello @laurencejackson, @tomaroberts  , I have fixed the ghosting script. The biggest problem was that the ghosting slice was always placed at random points in the image, not where it should have been, namely int the phase encoding direction. There is now a new function called get_ghosting_slice2 which selects the correct ghosting slice. I removed the old get_ghosting_slice function. 
I have had to change the code slightly in the main function and in the report_path if statement because it didn't plot correctly. 
Finally I changed the rescale_to_byte function because the original one changes the values and spreads them into a more widened histogram. I can put this back how it was but I think ideally that function will need to be changed at some point for all the hazenlib scripts.