### PR TITLE
Add output path

### DIFF
--- a/hazenlib/HazenTask.py
+++ b/hazenlib/HazenTask.py
@@ -4,14 +4,18 @@ HazenTask.py
 
 from pydicom import dcmread
 from hazenlib.logger import logger
+import pathlib
+import os
 
 
 class HazenTask:
 
-    def __init__(self, data_paths: list, report: bool = False):
+    def __init__(self, data_paths: list, report: bool = False, report_dir: str = os.getcwd()):
         self.data_paths = data_paths
         self.report: bool = report
-        self.report_path = self.key(self.data[0])
+        self.report_path = os.path.join(report_dir, type(self).__name__)
+        pathlib.Path(self.report_path).mkdir(parents=True, exist_ok=True)
+        self.report_files = []
 
     @property
     def data(self) -> list:
@@ -27,5 +31,4 @@ class HazenTask:
             metadata = [str(dcm.get(field)) for field in ['SeriesDescription', 'SeriesNumber']]
 
         key = f"{type(self).__name__}_" + '_'.join(metadata).replace(' ', '_')
-        self.report_path = key
         return key

--- a/hazenlib/__init__.py
+++ b/hazenlib/__init__.py
@@ -74,7 +74,7 @@ MMMMMMMMMMMMMMMMMMMMMMMMMMMMN0xc;;::cxXMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
 
 Welcome to the Hazen Command Line Interface
 Usage:
-    hazen <task> <folder> [--measured_slice_width=<mm>] [--report] [--calc_t1 | --calc_t2] [--plate_number=<n>] [--show_template_fit]
+    hazen <task> <folder> [--measured_slice_width=<mm>] [--report] [--output=<path>] [--calc_t1 | --calc_t2] [--plate_number=<n>] [--show_template_fit]
     [--show_relax_fits] [--show_rois] [--log=<lvl>] [--verbose]
     hazen -h|--help
     hazen -v|--version
@@ -332,10 +332,6 @@ def main():
 
     files = get_dicom_files(arguments['<folder>'])
     pp = pprint.PrettyPrinter(indent=4, depth=1, width=1)
-    if arguments['--report']:
-        report = True
-    else:
-        report = False
 
     log_levels = {
         "critical": logging.CRITICAL,
@@ -357,7 +353,10 @@ def main():
 
     if len(class_list) > 1:
         raise Exception(f'Task {task_module} has multiple class definitions: {class_list}')
-    task = getattr(task_module, class_list[0].__name__)(data_paths=files, report=report)
+    import os
+    task = getattr(task_module, class_list[0].__name__)(data_paths=files,
+                                                        report=arguments['--report'],
+                                                        report_dir=[arguments['--output'] if arguments['--output'] else os.getcwd()][0])
 
     if not arguments['<task>'] == 'snr' and arguments['--measured_slice_width']:
         raise Exception("the (--measured_slice_width) option can only be used with snr")

--- a/hazenlib/__init__.py
+++ b/hazenlib/__init__.py
@@ -367,7 +367,7 @@ def main():
     elif arguments['<task>'] == 'relaxometry':
         task = importlib.import_module(f"hazenlib.{arguments['<task>']}")
         dicom_objects = [pydicom.read_file(x, force=True) for x in files if is_dicom_file(x)]
-        result = parse_relaxometry_data(task, arguments, dicom_objects, report)
+        result = parse_relaxometry_data(task, arguments, dicom_objects, report=True)
     else:
         result = task.run()
 

--- a/hazenlib/tasks/ghosting.py
+++ b/hazenlib/tasks/ghosting.py
@@ -11,8 +11,8 @@ from hazenlib.HazenTask import HazenTask
 
 class Ghosting(HazenTask):
 
-    def __init__(self, data_paths: list, report=False):
-        super().__init__(data_paths, report=report)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     def run(self) -> dict:
         results = {}
@@ -25,6 +25,8 @@ class Ghosting(HazenTask):
                 print(f"Could not calculate the ghosting for {key} because of : {e}")
                 traceback.print_exc(file=sys.stdout)
                 continue
+
+        results['reports'] = self.report_files
 
         return results
 
@@ -244,7 +246,11 @@ class Ghosting(HazenTask):
             img = cv.rectangle(img.copy(), (x1, y1), (x2, y2), (255, 0, 0), 1)
 
             ax.imshow(img)
-            fig.savefig(f'{self.report_path}.png')
+            # fig.savefig(f'{self.report_path}.png')
+            img_path = os.path.realpath(os.path.join(self.report_path, f"{self.key(dcm, properties=['SeriesDescription', 'EchoTime', 'NumberOfAverages'])}.png"))
+            fig.savefig(img_path)
+            self.report_files.append(img_path)
+
             return fig, ghosting
 
         return None, ghosting

--- a/hazenlib/tasks/ghosting.py
+++ b/hazenlib/tasks/ghosting.py
@@ -15,18 +15,19 @@ class Ghosting(HazenTask):
         super().__init__(**kwargs)
 
     def run(self) -> dict:
-        results = {}
+        ghosting_results = {}
         for dcm in self.data:
             key = self.key(dcm, properties=['SeriesDescription', 'EchoTime', 'NumberOfAverages'])
             try:
-                fig, results[key] = self.get_ghosting(dcm)
+                fig, ghosting_results[key] = self.get_ghosting(dcm)
 
             except Exception as e:
                 print(f"Could not calculate the ghosting for {key} because of : {e}")
                 traceback.print_exc(file=sys.stdout)
                 continue
 
-        results['reports'] = self.report_files
+        results = {'ghosting_results': ghosting_results,
+                   'reports': self.report_files}
 
         return results
 
@@ -247,7 +248,8 @@ class Ghosting(HazenTask):
 
             ax.imshow(img)
             # fig.savefig(f'{self.report_path}.png')
-            img_path = os.path.realpath(os.path.join(self.report_path, f"{self.key(dcm, properties=['SeriesDescription', 'EchoTime', 'NumberOfAverages'])}.png"))
+            img_path = os.path.realpath(os.path.join(self.report_path,
+                                                     f"{self.key(dcm, properties=['SeriesDescription', 'EchoTime', 'NumberOfAverages'])}.png"))
             fig.savefig(img_path)
             self.report_files.append(img_path)
 

--- a/hazenlib/tasks/relaxometry.py
+++ b/hazenlib/tasks/relaxometry.py
@@ -3,7 +3,7 @@ from hazenlib.HazenTask import HazenTask
 
 class Relaxometry(HazenTask):
 
-    def __init__(self, data_paths: list, report=False):
+    def __init__(self, data_paths: list, report=False, report_dir=os.getcwd()):
         super().__init__(data_paths, report=report)
 
     def run(self):

--- a/hazenlib/tasks/relaxometry.py
+++ b/hazenlib/tasks/relaxometry.py
@@ -3,9 +3,9 @@ from hazenlib.HazenTask import HazenTask
 
 class Relaxometry(HazenTask):
 
-    def __init__(self, data_paths: list, report=False, report_dir=os.getcwd()):
-        super().__init__(data_paths, report=report)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     def run(self):
-        results = {'Not implemented yet': self}
+        results = {'Not implemented yet': {'Error': self}}
         return results

--- a/hazenlib/tasks/slice_position.py
+++ b/hazenlib/tasks/slice_position.py
@@ -23,8 +23,8 @@ import hazenlib.exceptions
 
 class SlicePosition(HazenTask):
 
-    def __init__(self, data_paths: list, report=False):
-        super().__init__(data_paths, report=report)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     def run(self) -> dict:
         if len(self.data) != 60:
@@ -45,7 +45,9 @@ class SlicePosition(HazenTask):
         result = [str(abs(decimal.Decimal(i) * 1)) for i in result]
         del decimal
 
-        results = {self.key(self.data[0]): result}
+        results = {self.key(self.data[0]): {'slice_positions': result},
+                   'reports': {'images': self.report_files}}
+
         return results
 
     def get_rod_rotation(self, x_pos: list, y_pos: list) -> float:
@@ -225,6 +227,9 @@ class SlicePosition(HazenTask):
 
             ax[1].scatter(range(10, 50), results, marker='x')
             ax[1].set_yticks(np.arange(-2.5, 2.5, 0.5))
-            fig.savefig(f'{self.report_path}_slice_position.png')
+
+            img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(self.data[0])}_slice_position.png'))
+            fig.savefig(img_path)
+            self.report_files.append(img_path)
 
         return results

--- a/hazenlib/tasks/slice_width.py
+++ b/hazenlib/tasks/slice_width.py
@@ -4,6 +4,7 @@ Square voxels, no multi-frame support
 """
 
 import sys
+import os
 import traceback
 from copy import copy
 from copy import deepcopy
@@ -22,20 +23,20 @@ from hazenlib.shapes import Rod
 
 class SliceWidth(HazenTask):
 
-    def __init__(self, data_paths: list, report=False):
-        super().__init__(data_paths, report=report)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     def run(self):
         results = {}
         for dcm in self.data:
             try:
-                result = self.get_slice_width(dcm)
+                results[self.key(dcm)] = self.get_slice_width(dcm)
             except Exception as e:
                 print(f"Could not calculate the slice_width for {self.key(dcm)} because of : {e}")
                 traceback.print_exc(file=sys.stdout)
                 continue
 
-            results[self.key(dcm)] = result
+        results['reports'] = {'images': self.report_files}
 
         return results
 
@@ -180,7 +181,9 @@ class SliceWidth(HazenTask):
             for idx in range(len(rods)):
                 axes[2].plot(rods_initial[idx].x, rods_initial[idx].y, 'y.')
                 axes[2].plot(rods[idx].x, rods[idx].y, 'r.')
-            fig.savefig(self.report_path + "_rod_centroids.png")
+            img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(dcm)}_rod_centroids.png'))
+            fig.savefig(img_path)
+            self.report_files.append(img_path)
 
         return rods, rods_initial
 
@@ -813,7 +816,9 @@ class SliceWidth(HazenTask):
                 loc="center"
             )
 
-            fig.savefig(self.report_path + '.png')
+            img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(dcm)}.png'))
+            fig.savefig(img_path)
+            self.report_files.append(img_path)
 
         # print(f"Series Description: {dcm.SeriesDescription}\nWidth: {dcm.Rows}\nHeight: {dcm.Columns}\nSlice Thickness(
         # mm):" f"{dcm.SliceThickness}\nField of View (mm): {hazenlib.get_field_of_view(dcm)}\nbandwidth (Hz/Px) : {

--- a/hazenlib/tasks/snr.py
+++ b/hazenlib/tasks/snr.py
@@ -42,7 +42,7 @@ class SNR(HazenTask):
             snr_results[f"snr_smoothing_measured_{self.key(dcm)}"] = round(snr, 2)
             snr_results[f"snr_smoothing_normalised_{self.key(dcm)}"] = round(normalised_snr, 2)
 
-        results = {'results': snr_results, 'reports': {'images': self.report_files}}
+        results = {self.key(self.data[0]): snr_results, 'reports': {'images': self.report_files}}
 
         return results
 

--- a/hazenlib/tasks/snr.py
+++ b/hazenlib/tasks/snr.py
@@ -11,6 +11,7 @@ Created by Neil Heraghty
 
 04/05/2018
 """
+import os
 import cv2 as cv
 import numpy as np
 import pydicom
@@ -26,20 +27,22 @@ from hazenlib.logger import logger
 
 class SNR(HazenTask):
 
-    def __init__(self, data_paths: list, report=False):
-        super().__init__(data_paths, report=report)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     def run(self, measured_slice_width=None) -> dict:
-        results = {}
+        snr_results = {}
         if len(self.data) == 2:
             snr, normalised_snr = self.snr_by_subtraction(self.data[0], self.data[1], measured_slice_width)
-            results[f"snr_subtraction_measured_{self.key(self.data[0])}"] = round(snr, 2)
-            results[f"snr_subtraction_normalised_{self.key(self.data[0])}"] = round(normalised_snr, 2)
+            snr_results[f"snr_subtraction_measured_{self.key(self.data[0])}"] = round(snr, 2)
+            snr_results[f"snr_subtraction_normalised_{self.key(self.data[0])}"] = round(normalised_snr, 2)
 
         for idx, dcm in enumerate(self.data):
             snr, normalised_snr = self.snr_by_smoothing(dcm, measured_slice_width)
-            results[f"snr_smoothing_measured_{self.key(dcm)}"] = round(snr, 2)
-            results[f"snr_smoothing_normalised_{self.key(dcm)}"] = round(normalised_snr, 2)
+            snr_results[f"snr_smoothing_measured_{self.key(dcm)}"] = round(snr, 2)
+            snr_results[f"snr_smoothing_normalised_{self.key(dcm)}"] = round(normalised_snr, 2)
+
+        results = {'results': snr_results, 'reports': {'images': self.report_files}}
 
         return results
 
@@ -319,7 +322,9 @@ class SNR(HazenTask):
             self.get_roi_samples(axes, dcm, col, row)
             axes.legend()
 
-            fig.savefig(self.report_path + ".png")
+            img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(dcm)}_smoothing.png'))
+            fig.savefig(img_path)
+            self.report_files.append(img_path)
 
         return snr, normalised_snr
 
@@ -372,6 +377,8 @@ class SNR(HazenTask):
             self.get_roi_samples(axes, dcm1, col, row)
             axes.legend()
 
-            fig.savefig(self.report_path + ".png")
+            img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(dcm1)}_snr_subtraction.png'))
+            fig.savefig(img_path)
+            self.report_files.append(img_path)
 
         return snr, normalised_snr

--- a/hazenlib/tasks/spatial_resolution.py
+++ b/hazenlib/tasks/spatial_resolution.py
@@ -10,6 +10,7 @@ Neil Heraghty, neil.heraghty@nhs.net, 16/05/2018
     
 """
 import copy
+import os
 import sys
 import traceback
 from hazenlib.logger import logger
@@ -24,8 +25,8 @@ from hazenlib.HazenTask import HazenTask
 
 class SpatialResolution(HazenTask):
 
-    def __init__(self, data_paths: list, report=False):
-        super().__init__(data_paths, report=report)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     def run(self) -> dict:
         results = {}
@@ -36,6 +37,8 @@ class SpatialResolution(HazenTask):
                 print(f"Could not calculate the spatial resolution for {self.key(dcm)} because of : {e}")
                 traceback.print_exc(file=sys.stdout)
                 continue
+
+        results['reports'] = {'images': self.report_files}
 
         return results
 
@@ -441,7 +444,9 @@ class SpatialResolution(HazenTask):
             axes[10].plot(freqs[mask], norm_mtf[mask])
             axes[10].set_xlabel('lp/mm')
             logger.info(f'Writing report image: {self.report_path}_{pe}_{edge}.png')
-            fig.savefig(f'{self.key(dicom)}_{pe}_{edge}.png')
+            img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(dicom)}_{pe}_{edge}.png'))
+            fig.savefig(img_path)
+            self.report_files.append(img_path)
 
         return res
 

--- a/hazenlib/tasks/uniformity.py
+++ b/hazenlib/tasks/uniformity.py
@@ -20,7 +20,7 @@ neil.heraghty@nhs.net
 
 import sys
 import traceback
-
+import os
 import numpy as np
 
 import hazenlib.tools
@@ -30,8 +30,8 @@ from hazenlib.HazenTask import HazenTask
 
 class Uniformity(HazenTask):
 
-    def __init__(self, data_paths: list, report=False):
-        super().__init__(data_paths, report=report)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     def run(self) -> dict:
         results = {}
@@ -45,6 +45,8 @@ class Uniformity(HazenTask):
                 continue
 
             results[self.key(dcm)] = result
+
+        results['reports'] = {'images': self.report_files}
 
         return results
 
@@ -140,7 +142,9 @@ class Uniformity(HazenTask):
             ax.add_collection(pc)
             ax.scatter(x, y, 5)
 
-            fig.savefig(self.report_path + ".png")
+            img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(dcm)}.png'))
+            fig.savefig(img_path)
+            self.report_files.append(img_path)
 
         return {'horizontal': {'IPEM': fractional_uniformity_horizontal},
                 'vertical': {'IPEM': fractional_uniformity_vertical}}

--- a/tests/test_hazenlib.py
+++ b/tests/test_hazenlib.py
@@ -208,8 +208,8 @@ class TestCliParser(unittest.TestCase):
                  'snr_smoothing_normalised_SNR_SNR_SAG_MEAS1_23_1': 7610.83}
 
         maxDiff = None
-        output_dict == dict1
-        self.assertDictEqual(output_dict, dict1)
+        output_dict['SNR_SNR_SAG_MEAS2_24_1'] == dict1
+        self.assertDictEqual(output_dict['SNR_SNR_SAG_MEAS2_24_1'], dict1)
 
     def test_relaxometry(self):
         sys.argv = ["hazen", "relaxometry", ".\\tests\\data\\relaxometry\\T1\\site3_ge\\plate4\\", "--plate_number",

--- a/tests/test_slice_position.py
+++ b/tests/test_slice_position.py
@@ -39,7 +39,7 @@ class TestSlicePosition(unittest.TestCase):
     def test_slice_position(self):
         results = self.hazen_slice_position.run()
 
-        assert results[self.hazen_slice_position.key(self.hazen_slice_position.data[0])] == self.SLICE_POSITION_OUTPUT
+        assert results[self.hazen_slice_position.key(self.hazen_slice_position.data[0])]['slice_positions'] == self.SLICE_POSITION_OUTPUT
 
 
 # now test on canon data

--- a/tests/test_snr.py
+++ b/tests/test_snr.py
@@ -35,9 +35,9 @@ class TestSnr(unittest.TestCase):
 
     def test_image_snr(self):
         val = self.snr.run()
-        self.assertTrue(self.LOWER_SMOOTHED_SNR <= val[
+        self.assertTrue(self.LOWER_SMOOTHED_SNR <= val[self.snr.key(self.snr.data[0])][
             f"snr_smoothing_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SMOOTHED_SNR)
-        self.assertTrue(self.LOWER_SUBTRACT_SNR <= val[
+        self.assertTrue(self.LOWER_SUBTRACT_SNR <= val[self.snr.key(self.snr.data[0])][
             f"snr_subtraction_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SUBTRACT_SNR)
 
     def test_SNR_factor(self):

--- a/tests/test_snr.py
+++ b/tests/test_snr.py
@@ -106,9 +106,9 @@ class TestSnrGE(TestSnr):
         # val = self.snr.run(data=[self.test_file, self.test_file_2])
         val = self.snr.run()
         self.assertTrue(
-            self.LOWER_SMOOTHED_SNR <= val[f"snr_smoothing_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SMOOTHED_SNR)
+            self.LOWER_SMOOTHED_SNR <= val[self.snr.key(self.snr.data[0])][f"snr_smoothing_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SMOOTHED_SNR)
         self.assertTrue(
-            self.LOWER_SUBTRACT_SNR <= val[f"snr_subtraction_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SUBTRACT_SNR)
+            self.LOWER_SUBTRACT_SNR <= val[self.snr.key(self.snr.data[0])][f"snr_subtraction_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SUBTRACT_SNR)
 
 
 class TestSnrThreshold(TestSnr):

--- a/tests/test_snr.py
+++ b/tests/test_snr.py
@@ -72,8 +72,8 @@ class TestSnrPhilips(TestSnr):
 
     def test_image_snr(self):
         val = self.snr.run()
-        self.assertTrue(self.LOWER_SMOOTHED_SNR <= val[f"snr_smoothing_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SMOOTHED_SNR)
-        self.assertTrue(self.LOWER_SUBTRACT_SNR <= val[
+        self.assertTrue(self.LOWER_SMOOTHED_SNR <= val[self.snr.key(self.snr.data[0])][f"snr_smoothing_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SMOOTHED_SNR)
+        self.assertTrue(self.LOWER_SUBTRACT_SNR <= val[self.snr.key(self.snr.data[0])][
             f"snr_subtraction_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SUBTRACT_SNR)
 
 
@@ -139,7 +139,7 @@ class TestSnrThreshold(TestSnr):
 
     def test_image_snr(self):
         val = self.snr.run()
-        self.assertTrue(self.LOWER_SMOOTHED_SNR <= val[
+        self.assertTrue(self.LOWER_SMOOTHED_SNR <= val[self.snr.key(self.snr.data[0])][
             f"snr_smoothing_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SMOOTHED_SNR)
-        self.assertTrue(self.LOWER_SUBTRACT_SNR <= val[
+        self.assertTrue(self.LOWER_SUBTRACT_SNR <= val[self.snr.key(self.snr.data[0])][
             f"snr_subtraction_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SUBTRACT_SNR)


### PR DESCRIPTION
Adds output path to hazenlib tasks

returns paths to report objects in results dictionary, so these can be accessed in website UI.