### PR TITLE
added new tasks to the CLI

### DIFF
--- a/hazenlib/__init__.py
+++ b/hazenlib/__init__.py
@@ -85,7 +85,7 @@ Report is an optional argument needed if you want to get a plot of your results.
 'Measured_slice_width' is an optional argument for the SNR function.
 'Log' is an optional argument that allows users to set the severity of the logs.
     <task>    snr | slice_position | slice_width | spatial_resolution | uniformity | ghosting | relaxometry | snr_map |
-    acr_ghosting | acr_uniformity | acr_spatial_resolution | acr_slice_thickness
+    acr_ghosting | acr_uniformity | acr_spatial_resolution | acr_slice_thickness | acr_snr | acr_slice_position | acr_geometric_accuracy
     <folder>
     --report
 

--- a/hazenlib/__init__.py
+++ b/hazenlib/__init__.py
@@ -85,7 +85,7 @@ Report is an optional argument needed if you want to get a plot of your results.
 'Measured_slice_width' is an optional argument for the SNR function.
 'Log' is an optional argument that allows users to set the severity of the logs.
     <task>    snr | slice_position | slice_width | spatial_resolution | uniformity | ghosting | relaxometry | snr_map |
-    acr_ghosting | acr_uniformity |
+    acr_ghosting | acr_uniformity | acr_spatial_resolution | acr_slice_thickness
     <folder>
     --report
 


### PR DESCRIPTION
Two tasks were added by Yassine:

1) ACR_spatial_res and 2)acr_slice_thickness.

They both run correctly, however they didn't show up in the CLI so when someone types hazen --help they are not included in what the docstring prints out.

I have now added these. 

@heyhaleema, could you please check this out?