### PR TITLE
374 standardise task input and output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ dist
 # data
 uploads
 *.png
-report
+report*
 # TODO: Remove the following if no longer needed
 hazenlib/data
 

--- a/hazenlib/ACRObject.py
+++ b/hazenlib/ACRObject.py
@@ -6,12 +6,19 @@ import skimage
 
 class ACRObject:
     def __init__(self, dcm_list):
+        # Initialise an ACR object from a stack of images of the ACR phantom
         self.dcm_list = dcm_list
+        # Load files as DICOM and their pixel arrays into 'images'
         self.images, self.dcms = self.sort_images()
+        # Store the pixel spacing value from the first image (expected to be the same for all)
         self.pixel_spacing = self.dcms[0].PixelSpacing
+        # Check whether images of the phantom are the correct orientation
         self.orientation_checks()
+        # Determine whether image rotation is necessary
         self.rot_angle = self.determine_rotation()
+        # Find the centre coordinates of the phantom (circle)
         self.centre, self.radius = self.find_phantom_center()
+        # Store a mask image of slice 7 for reusability
         self.mask_image = self.get_mask_image(self.images[6])
 
     def sort_images(self):

--- a/hazenlib/ACRObject.py
+++ b/hazenlib/ACRObject.py
@@ -13,7 +13,6 @@ class ACRObject:
         self.rot_angle = self.determine_rotation()
         self.centre, self.radius = self.find_phantom_center()
         self.mask_image = self.get_mask_image(self.images[6])
-        self.length_dict = self.measure_orthogonal_lengths(self.mask_image)
 
     def sort_images(self):
         """

--- a/hazenlib/ACRObject.py
+++ b/hazenlib/ACRObject.py
@@ -5,12 +5,15 @@ import skimage
 
 
 class ACRObject:
-    def __init__(self, dcm):
-        self.dcm = dcm
-        self.images, self.dcm = self.sort_images()
+    def __init__(self, dcm_list):
+        self.dcm_list = dcm_list
+        self.images, self.dcms = self.sort_images()
+        self.pixel_spacing = self.dcms[0].PixelSpacing
         self.orientation_checks()
         self.rot_angle = self.determine_rotation()
         self.centre, self.radius = self.find_phantom_center()
+        self.mask_image = self.get_mask_image(self.images[6])
+        self.length_dict = self.measure_orthogonal_lengths(self.mask_image)
 
     def sort_images(self):
         """
@@ -24,8 +27,8 @@ class ACRObject:
             A sorted stack of dicoms
         """
 
-        z = np.array([dcm_file.ImagePositionPatient[2] for dcm_file in self.dcm])
-        dicom_stack = [self.dcm[i] for i in np.argsort(z)]
+        z = np.array([dcm.ImagePositionPatient[2] for dcm in self.dcm_list])
+        dicom_stack = [self.dcm_list[i] for i in np.argsort(z)]
         img_stack = [dicom.pixel_array for dicom in dicom_stack]
 
         return img_stack, dicom_stack
@@ -41,31 +44,38 @@ class ACRObject:
         adjustments are needed to restore the correct slice order and view orientation.
         """
         test_images = (self.images[0], self.images[-1])
+        dx = self.pixel_spacing[0]
 
-        pixel_spacing = self.dcm[0].PixelSpacing
-
-        normalised_images = [cv2.normalize(src=image, dst=None, alpha=0, beta=255, norm_type=cv2.NORM_MINMAX,
-                                           dtype=cv2.CV_8U) for image in test_images]
+        normalised_images = [cv2.normalize(
+                                src=image, dst=None, alpha=0, beta=255,
+                                norm_type=cv2.NORM_MINMAX, dtype=cv2.CV_8U
+                            ) for image in test_images]
 
         # search for circle in first slice of ACR phantom dataset with radius of ~11mm
-        detected_circles = [cv2.HoughCircles(norm_image, cv2.HOUGH_GRADIENT, 1, minDist=int(180 / pixel_spacing[0]),
-                                             param1=50, param2=30, minRadius=int(5 / pixel_spacing[0]),
-                                             maxRadius=int(16 / pixel_spacing[0])) for norm_image in normalised_images]
+        detected_circles = [cv2.HoughCircles(
+                                norm_image, cv2.HOUGH_GRADIENT, 1,
+                                param1=50, param2=30,
+                                minDist=int(180 / dx),
+                                minRadius=int(5 / dx),
+                                maxRadius=int(16 / dx)
+                            ) for norm_image in normalised_images]
 
-        true_circle = detected_circles[0].flatten() if detected_circles[0] is not None else detected_circles[
-            1].flatten()
+        if detected_circles[0] is not None:
+            true_circle = detected_circles[0].flatten()
+        else:
+            true_circle = detected_circles[1].flatten()
 
         if detected_circles[0] is None and detected_circles[1] is not None:
             print('Performing slice order inversion to restore correct slice order.')
             self.images.reverse()
-            self.dcm.reverse()
+            self.dcms.reverse()
         else:
             print('Slice order inversion not required.')
 
         if true_circle[0] > self.images[0].shape[0] // 2:
             print('Performing LR orientation swap to restore correct view.')
             flipped_images = [np.fliplr(image) for image in self.images]
-            for index, dcm in enumerate(self.dcm):
+            for index, dcm in enumerate(self.dcms):
                 dcm.PixelData = flipped_images[index].tobytes()
         else:
             print('LR orientation swap not required.')
@@ -106,7 +116,34 @@ class ACRObject:
 
         return skimage.transform.rotate(self.images, self.rot_angle, resize=False, preserve_range=True)
 
-    def mask_image(self, image, mag_threshold=0.05, open_threshold=500):
+    def find_phantom_center(self):
+        """
+        Find the center of the ACR phantom by filtering the uniformity slice and using the Hough circle detector.
+
+
+        Returns
+        -------
+        centre  : tuple
+            Tuple of ints representing the (x, y) center of the image.
+        """
+        img = self.images[6]
+        dx, dy = self.pixel_spacing
+        img_blur = cv2.GaussianBlur(img, (1, 1), 0)
+        img_grad = cv2.Sobel(img_blur, 0, dx=1, dy=1)
+
+        detected_circles = cv2.HoughCircles(
+                                img_grad, cv2.HOUGH_GRADIENT, 1,
+                                param1=50, param2=30,
+                                minDist=int(180 / dy),
+                                minRadius=int(180 / (2 * dy)),
+                                maxRadius=int(200 / (2 * dx))
+                            ).flatten()
+
+        centre = [int(i) for i in detected_circles[:2]]
+        radius = int(detected_circles[2])
+        return centre, radius
+
+    def get_mask_image(self, image, mag_threshold=0.05, open_threshold=500):
         """
         Mask an image by magnitude threshold before applying morphological opening to remove small unconnected
         features. The convex hull is calculated in order to accommodate for potential air bubbles.
@@ -116,7 +153,7 @@ class ACRObject:
         np.array:
             The masked image.
         """
-        test_mask = self.circular_mask(self.centre, (80 // self.dcm[0].PixelSpacing[0]), image.shape)
+        test_mask = self.circular_mask(self.centre, (80 // self.pixel_spacing[0]), image.shape)
         test_image = image * test_mask
         test_vals = test_image[np.nonzero(test_image)]
         if np.percentile(test_vals, 80) - np.percentile(test_vals, 10) > 0.9 * np.max(image):
@@ -129,28 +166,6 @@ class ACRObject:
         final_mask = skimage.morphology.convex_hull_image(opened_mask)
 
         return final_mask
-
-    def find_phantom_center(self):
-        """
-        Find the center of the ACR phantom by filtering the uniformity slice and using the Hough circle detector.
-
-
-        Returns
-        -------
-        centre  : tuple
-            Tuple of ints representing the (x, y) center of the image.
-        """
-        img = self.images[6]
-        dx, dy = self.dcm[6].PixelSpacing
-        img_blur = cv2.GaussianBlur(img, (1, 1), 0)
-        img_grad = cv2.Sobel(img_blur, 0, dx=1, dy=1)
-
-        detected_circles = cv2.HoughCircles(img_grad, cv2.HOUGH_GRADIENT, 1,
-                                            minDist=int(180 / dy), param1=50, param2=30,
-                                            minRadius=int(180 / (2 * dy)), maxRadius=int(200 / (2 * dx))).flatten()
-
-        centre, radius = [int(i) for i in detected_circles[:2]], int(detected_circles[2])
-        return centre, radius
 
     @staticmethod
     def circular_mask(centre, radius, dims):
@@ -203,19 +218,21 @@ class ACRObject:
                 The horizontal/vertical length of the object.
         """
         dims = mask.shape
-        res = self.dcm[0].PixelSpacing
+        dx, dy = self.pixel_spacing
 
         horizontal_start = (self.centre[1], 0)
         horizontal_end = (self.centre[1], dims[0] - 1)
-        horizontal_line_profile = skimage.measure.profile_line(mask, horizontal_start, horizontal_end)
+        horizontal_line_profile = skimage.measure.profile_line(
+                            mask, horizontal_start, horizontal_end)
         horizontal_extent = np.nonzero(horizontal_line_profile)[0]
-        horizontal_distance = (horizontal_extent[-1] - horizontal_extent[0]) * res[0]
+        horizontal_distance = (horizontal_extent[-1] - horizontal_extent[0]) * dx
 
         vertical_start = (0, self.centre[0])
         vertical_end = (dims[1] - 1, self.centre[0])
-        vertical_line_profile = skimage.measure.profile_line(mask, vertical_start, vertical_end)
+        vertical_line_profile = skimage.measure.profile_line(
+                            mask, vertical_start, vertical_end)
         vertical_extent = np.nonzero(vertical_line_profile)[0]
-        vertical_distance = (vertical_extent[-1] - vertical_extent[0]) * res[1]
+        vertical_distance = (vertical_extent[-1] - vertical_extent[0]) * dy
 
         length_dict = {
             'Horizontal Start': horizontal_start,

--- a/hazenlib/HazenTask.py
+++ b/hazenlib/HazenTask.py
@@ -10,7 +10,7 @@ import os
 
 class HazenTask:
 
-    def __init__(self, input_data, report: bool = False, report_dir: str = ""):
+    def __init__(self, input_data, report: bool = False, report_dir = None):
         # Check if input data is a single or list of files, load accordingly
         if isinstance(input_data, list):
             data_paths = sorted(input_data)
@@ -18,7 +18,11 @@ class HazenTask:
         else:
             self.single_dcm = dcmread(input_data)
         self.report: bool = report
-        self.report_path = os.path.join(report_dir, type(self).__name__)
+        if report_dir is not None:
+            self.report_path = os.path.join(str(report_dir), type(self).__name__)
+        else:
+            self.report_path = os.path.join(os.getcwd(), 'report_image',
+                                            type(self).__name__)
         if report:
             pathlib.Path(self.report_path).mkdir(parents=True, exist_ok=True)
         else:

--- a/hazenlib/HazenTask.py
+++ b/hazenlib/HazenTask.py
@@ -10,7 +10,7 @@ import os
 
 class HazenTask:
 
-    def __init__(self, input_data, report: bool = False, report_dir: str = os.path.join(os.getcwd(), 'report')):
+    def __init__(self, input_data, report: bool = False, report_dir: str = ""):
         # Check if input data is a single or list of files, load accordingly
         if isinstance(input_data, list):
             data_paths = sorted(input_data)
@@ -26,10 +26,14 @@ class HazenTask:
         self.report_files = []
 
     def init_result_dict(self) -> dict:
-        result_dict = {"task": f"{type(self).__name__}"}
+        result_dict = {
+            "task": f"{type(self).__name__}",
+            "file": None,
+            "measurement": None
+        }
         return result_dict
 
-    def key(self, dcm, properties=None) -> str:
+    def img_desc(self, dcm, properties=None) -> str:
         if properties is None:
             properties = ['SeriesDescription', 'SeriesNumber', 'InstanceNumber']
         try:
@@ -38,5 +42,5 @@ class HazenTask:
             logger.warning(f"Could not find one or more of the following properties: {properties}")
             metadata = [str(dcm.get(field)) for field in ['SeriesDescription', 'SeriesNumber']]
 
-        key =  '_'.join(metadata).replace(' ', '_')
-        return key
+        img_desc =  '_'.join(metadata).replace(' ', '_')
+        return img_desc

--- a/hazenlib/HazenTask.py
+++ b/hazenlib/HazenTask.py
@@ -10,13 +10,9 @@ import os
 
 class HazenTask:
 
-    def __init__(self, input_data, report: bool = False, report_dir=None):
-        # Check if input data is a single or list of files, load accordingly
-        if isinstance(input_data, list):
-            data_paths = sorted(input_data)
-            self.dcm_list = [dcmread(dicom)for dicom in data_paths]
-        else:
-            self.single_dcm = dcmread(input_data)
+    def __init__(self, input_data: list, report: bool = False, report_dir=None):
+        data_paths = sorted(input_data)
+        self.dcm_list = [dcmread(dicom)for dicom in data_paths]
         self.report: bool = report
         if report_dir is not None:
             self.report_path = os.path.join(str(report_dir), type(self).__name__)

--- a/hazenlib/HazenTask.py
+++ b/hazenlib/HazenTask.py
@@ -28,6 +28,11 @@ class HazenTask:
     def data(self) -> list:
         return [dcmread(dicom)for dicom in self.data_paths]
 
+    def init_result_dict(self) -> dict:
+        result_dict = {"task": f"{type(self).__name__}"}
+        return result_dict
+
+
     def key(self, dcm, properties=None) -> str:
         if properties is None:
             properties = ['SeriesDescription', 'SeriesNumber', 'InstanceNumber']
@@ -37,5 +42,5 @@ class HazenTask:
             logger.warning(f"Could not find one or more of the following properties: {properties}")
             metadata = [str(dcm.get(field)) for field in ['SeriesDescription', 'SeriesNumber']]
 
-        key = f"{type(self).__name__}_" + '_'.join(metadata).replace(' ', '_')
+        key =  '_'.join(metadata).replace(' ', '_')
         return key

--- a/hazenlib/HazenTask.py
+++ b/hazenlib/HazenTask.py
@@ -13,7 +13,8 @@ class HazenTask:
     def __init__(self, input_data, report: bool = False, report_dir: str = os.path.join(os.getcwd(), 'report')):
         # Check if input data is a single or list of files, load accordingly
         if isinstance(input_data, list):
-            self.data_paths = sorted(input_data)
+            data_paths = sorted(input_data)
+            self.dcm_list = [dcmread(dicom)for dicom in data_paths]
         else:
             self.single_dcm = dcmread(input_data)
         self.report: bool = report
@@ -24,14 +25,9 @@ class HazenTask:
             pass
         self.report_files = []
 
-    @property
-    def data(self) -> list:
-        return [dcmread(dicom)for dicom in self.data_paths]
-
     def init_result_dict(self) -> dict:
         result_dict = {"task": f"{type(self).__name__}"}
         return result_dict
-
 
     def key(self, dcm, properties=None) -> str:
         if properties is None:

--- a/hazenlib/HazenTask.py
+++ b/hazenlib/HazenTask.py
@@ -29,7 +29,7 @@ class HazenTask:
         result_dict = {
             "task": f"{type(self).__name__}",
             "file": None,
-            "measurement": None
+            "measurement": {}
         }
         return result_dict
 

--- a/hazenlib/HazenTask.py
+++ b/hazenlib/HazenTask.py
@@ -10,7 +10,7 @@ import os
 
 class HazenTask:
 
-    def __init__(self, input_data, report: bool = False, report_dir = None):
+    def __init__(self, input_data, report: bool = False, report_dir=None):
         # Check if input data is a single or list of files, load accordingly
         if isinstance(input_data, list):
             data_paths = sorted(input_data)
@@ -46,5 +46,5 @@ class HazenTask:
             logger.warning(f"Could not find one or more of the following properties: {properties}")
             metadata = [str(dcm.get(field)) for field in ['SeriesDescription', 'SeriesNumber']]
 
-        img_desc =  '_'.join(metadata).replace(' ', '_')
+        img_desc = '_'.join(metadata).replace(' ', '_')
         return img_desc

--- a/hazenlib/HazenTask.py
+++ b/hazenlib/HazenTask.py
@@ -10,8 +10,12 @@ import os
 
 class HazenTask:
 
-    def __init__(self, data_paths: list, report: bool = False, report_dir: str = os.path.join(os.getcwd(), 'report')):
-        self.data_paths = sorted(data_paths)
+    def __init__(self, input_data, report: bool = False, report_dir: str = os.path.join(os.getcwd(), 'report')):
+        # Check if input data is a single or list of files, load accordingly
+        if isinstance(input_data, list):
+            self.data_paths = sorted(input_data)
+        else:
+            self.single_dcm = dcmread(input_data)
         self.report: bool = report
         self.report_path = os.path.join(report_dir, type(self).__name__)
         if report:

--- a/hazenlib/__init__.py
+++ b/hazenlib/__init__.py
@@ -111,17 +111,26 @@ relaxometry Task options:
 import importlib
 import inspect
 import logging
-import sys
 import json
-import os
+import sys
 
 from docopt import docopt
-import pydicom
 from hazenlib.logger import logger
-from hazenlib.utils import is_dicom_file, get_dicom_files
+from hazenlib.utils import get_dicom_files
 from hazenlib._version import __version__
 
+"""
+Hazen is designed to measure the same parameters from multiple images.
+While some tasks require a set of multiple images (within the same folder),
+such as slice position, SNR and all ACR tasks,
+the majority of the calculations are performed on a single image at a time,
+and bulk processing all images in the input folder with the same task.
 
+In Sep 2023 a design decision was made to pass the minimum number of files
+to the task.run() functions.
+Below is a list of the single image tasks where the task.run() will be called
+on each image in the folder, while other tasks are being passed ALL image files.
+"""
 single_image_tasks = ["ghosting", "uniformity", "spatial_resolution",
                       "slice_width", "snr_map"]
 

--- a/hazenlib/__init__.py
+++ b/hazenlib/__init__.py
@@ -167,8 +167,7 @@ def main():
         logging.getLogger().setLevel(logging.INFO)
 
     report = arguments['--report']
-    report_dir = arguments['--output'] if arguments['--output'] else os.path.join(
-                os.getcwd(), 'report_image')
+    report_dir = arguments['--output'] if arguments['--output'] else None
 
     # Parse the task and optional arguments:
     if arguments['snr'] or arguments['<task>'] == 'snr':

--- a/hazenlib/__init__.py
+++ b/hazenlib/__init__.py
@@ -209,7 +209,7 @@ def main():
         selected_task = arguments['<task>']
         if selected_task in single_image_tasks:
             for file in files:
-                task = init_task(selected_task, file, report, report_dir)
+                task = init_task(selected_task, [file], report, report_dir)
                 result = task.run()
                 result_string = json.dumps(result, indent=2)
                 print(result_string)

--- a/hazenlib/__init__.py
+++ b/hazenlib/__init__.py
@@ -168,7 +168,7 @@ def main():
 
     report = arguments['--report']
     report_dir = arguments['--output'] if arguments['--output'] else os.path.join(
-                os.getcwd(), 'report')
+                os.getcwd(), 'report_image')
 
     # Parse the task and optional arguments:
     if arguments['snr'] or arguments['<task>'] == 'snr':

--- a/hazenlib/tasks/acr_geometric_accuracy.py
+++ b/hazenlib/tasks/acr_geometric_accuracy.py
@@ -68,7 +68,7 @@ class ACRGeometricAccuracy(HazenTask):
 
         # only return reports if requested
         if self.report:
-            results['reports'] = {'images': self.report_files}
+            results['report_images'] = self.report_files
 
         return results
 

--- a/hazenlib/tasks/acr_geometric_accuracy.py
+++ b/hazenlib/tasks/acr_geometric_accuracy.py
@@ -38,7 +38,7 @@ class ACRGeometricAccuracy(HazenTask):
         self.ACR_obj = None
 
     def run(self) -> dict:
-        results = {}
+        results = self.init_result_dict()
         self.ACR_obj = ACRObject(self.data)
         slice1_dcm = self.ACR_obj.dcm[0]
         slice5_dcm = self.ACR_obj.dcm[4]

--- a/hazenlib/tasks/acr_geometric_accuracy.py
+++ b/hazenlib/tasks/acr_geometric_accuracy.py
@@ -39,7 +39,7 @@ class ACRGeometricAccuracy(HazenTask):
 
     def run(self) -> dict:
         results = self.init_result_dict()
-        self.ACR_obj = ACRObject(self.data)
+        self.ACR_obj = ACRObject(self.dcm_list)
         slice1_dcm = self.ACR_obj.dcm[0]
         slice5_dcm = self.ACR_obj.dcm[4]
 

--- a/hazenlib/tasks/acr_ghosting.py
+++ b/hazenlib/tasks/acr_ghosting.py
@@ -28,23 +28,28 @@ class ACRGhosting(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.ACR_obj = None
 
     def run(self) -> dict:
-        results = self.init_result_dict()
+        # Initialise ACR object
         self.ACR_obj = ACRObject(self.dcm_list)
-        ghosting_dcm = self.ACR_obj.dcm[6]
+        ghosting_dcm = self.ACR_obj.dcms[6]
+
+        # Initialise results dictionary
+        results = self.init_result_dict()
+        results['file'] = self.img_desc(ghosting_dcm)
 
         try:
             result = self.get_signal_ghosting(ghosting_dcm)
-            results[self.key(ghosting_dcm)] = result
+            results['measurement'] = {
+                "signal ghosting %": round(result, 3)
+                }
         except Exception as e:
-            print(f"Could not calculate the percent-signal ghosting for {self.key(ghosting_dcm)} because of : {e}")
+            print(f"Could not calculate the percent-signal ghosting for {self.img_desc(ghosting_dcm)} because of : {e}")
             traceback.print_exc(file=sys.stdout)
 
         # only return reports if requested
         if self.report:
-            results['report_images'] = self.report_files
+            results['report_image'] = self.report_files
 
         return results
 
@@ -54,7 +59,7 @@ class ACRGhosting(HazenTask):
         r_large = np.ceil(80 / res[0]).astype(int)  # Required pixel radius to produce ~200cm2 ROI
         dims = img.shape
 
-        mask = self.ACR_obj.mask_image(img)
+        mask = self.ACR_obj.mask_image
         cxy = self.ACR_obj.centre
 
         nx = np.linspace(1, dims[0], dims[0])
@@ -139,8 +144,6 @@ class ACRGhosting(HazenTask):
         psg = 100 * np.absolute(
             ((n_ellipse_val + s_ellipse_val) - (w_ellipse_val + e_ellipse_val)) / (2 * large_roi_val))
 
-        psg = np.round(psg, 3)
-
         if self.report:
             import matplotlib.pyplot as plt
             fig, axes = plt.subplots(2, 1)
@@ -181,7 +184,8 @@ class ACRGhosting(HazenTask):
 
             axes[1].axis('off')
             axes[1].set_title('Percent Signal Ghosting = ' + str(np.round(psg, 3)) + '%')
-            img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(dcm)}.png'))
+            img_path = os.path.realpath(os.path.join(
+                self.report_path, f'{self.img_desc(dcm)}.png'))
             fig.savefig(img_path)
             self.report_files.append(img_path)
 

--- a/hazenlib/tasks/acr_ghosting.py
+++ b/hazenlib/tasks/acr_ghosting.py
@@ -32,7 +32,7 @@ class ACRGhosting(HazenTask):
 
     def run(self) -> dict:
         results = self.init_result_dict()
-        self.ACR_obj = ACRObject(self.data)
+        self.ACR_obj = ACRObject(self.dcm_list)
         ghosting_dcm = self.ACR_obj.dcm[6]
 
         try:

--- a/hazenlib/tasks/acr_ghosting.py
+++ b/hazenlib/tasks/acr_ghosting.py
@@ -44,7 +44,7 @@ class ACRGhosting(HazenTask):
 
         # only return reports if requested
         if self.report:
-            results['reports'] = {'images': self.report_files}
+            results['report_images'] = self.report_files
 
         return results
 

--- a/hazenlib/tasks/acr_ghosting.py
+++ b/hazenlib/tasks/acr_ghosting.py
@@ -31,7 +31,7 @@ class ACRGhosting(HazenTask):
         self.ACR_obj = None
 
     def run(self) -> dict:
-        results = {}
+        results = self.init_result_dict()
         self.ACR_obj = ACRObject(self.data)
         ghosting_dcm = self.ACR_obj.dcm[6]
 

--- a/hazenlib/tasks/acr_slice_position.py
+++ b/hazenlib/tasks/acr_slice_position.py
@@ -43,7 +43,7 @@ class ACRSlicePosition(HazenTask):
         self.ACR_obj = None
 
     def run(self) -> dict:
-        results = {}
+        results = self.init_result_dict()
         self.ACR_obj = ACRObject(self.data)
         dcms = [self.ACR_obj.dcm[0], self.ACR_obj.dcm[-1]]
         for dcm in dcms:

--- a/hazenlib/tasks/acr_slice_position.py
+++ b/hazenlib/tasks/acr_slice_position.py
@@ -44,7 +44,7 @@ class ACRSlicePosition(HazenTask):
 
     def run(self) -> dict:
         results = self.init_result_dict()
-        self.ACR_obj = ACRObject(self.data)
+        self.ACR_obj = ACRObject(self.dcm_list)
         dcms = [self.ACR_obj.dcm[0], self.ACR_obj.dcm[-1]]
         for dcm in dcms:
             try:

--- a/hazenlib/tasks/acr_slice_position.py
+++ b/hazenlib/tasks/acr_slice_position.py
@@ -56,7 +56,7 @@ class ACRSlicePosition(HazenTask):
                 continue
         # only return reports if requested
         if self.report:
-            results['reports'] = {'images': self.report_files}
+            results['report_images'] = self.report_files
 
         return results
 

--- a/hazenlib/tasks/acr_slice_thickness.py
+++ b/hazenlib/tasks/acr_slice_thickness.py
@@ -43,7 +43,7 @@ class ACRSliceThickness(HazenTask):
 
         # only return reports if requested
         if self.report:
-            results['reports'] = {'images': self.report_files}
+            results['report_images'] = self.report_files
 
         return results
 

--- a/hazenlib/tasks/acr_slice_thickness.py
+++ b/hazenlib/tasks/acr_slice_thickness.py
@@ -32,7 +32,7 @@ class ACRSliceThickness(HazenTask):
 
     def run(self) -> dict:
         results = self.init_result_dict()
-        self.ACR_obj = ACRObject(self.data)
+        self.ACR_obj = ACRObject(self.dcm_list)
         slice_thickness_dcm = self.ACR_obj.dcm[0]
         try:
             result = self.get_slice_thickness(slice_thickness_dcm)

--- a/hazenlib/tasks/acr_slice_thickness.py
+++ b/hazenlib/tasks/acr_slice_thickness.py
@@ -31,7 +31,7 @@ class ACRSliceThickness(HazenTask):
         self.ACR_obj = None
 
     def run(self) -> dict:
-        results = {}
+        results = self.init_result_dict()
         self.ACR_obj = ACRObject(self.data)
         slice_thickness_dcm = self.ACR_obj.dcm[0]
         try:

--- a/hazenlib/tasks/acr_snr.py
+++ b/hazenlib/tasks/acr_snr.py
@@ -78,7 +78,7 @@ class ACRSNR(HazenTask):
 
         # only return reports if requested
         if self.report:
-            results['reports'] = {'images': self.report_files}
+            results['report_images'] = self.report_files
 
         return results
 

--- a/hazenlib/tasks/acr_snr.py
+++ b/hazenlib/tasks/acr_snr.py
@@ -36,15 +36,13 @@ class ACRSNR(HazenTask):
         super().__init__(**kwargs)
         self.ACR_obj = None
 
-        self.data2 = []
-
     def run(self, measured_slice_width=None, subtract=None) -> dict:
         
         if measured_slice_width is not None:
             measured_slice_width = float(measured_slice_width)
         
         snr_results = {}
-        self.ACR_obj = [ACRObject(self.data)]
+        self.ACR_obj = [ACRObject(self.dcm_list)]
         snr_dcm = self.ACR_obj[0].dcm[6]
 
         # SINGLE METHOD (SMOOTHING)

--- a/hazenlib/tasks/acr_spatial_resolution.py
+++ b/hazenlib/tasks/acr_spatial_resolution.py
@@ -78,7 +78,7 @@ class ACRSpatialResolution(HazenTask):
 
         # only return reports if requested
         if self.report:
-            results['reports'] = {'images': self.report_files}
+            results['report_images'] = self.report_files
 
         return results
 

--- a/hazenlib/tasks/acr_spatial_resolution.py
+++ b/hazenlib/tasks/acr_spatial_resolution.py
@@ -52,33 +52,36 @@ class ACRSpatialResolution(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.ACR_obj = None
 
     def run(self) -> dict:
-        mtf_results = {}
+        # Initialise ACR object
         self.ACR_obj = ACRObject(self.dcm_list)
-        rot_ang = self.ACR_obj.rot_angle
 
-        if np.round(np.abs(rot_ang), 2) < 3:
+        rot_ang = self.ACR_obj.rot_angle
+        if np.abs(rot_ang) < 3:
             logger.warning(f'The estimated rotation angle of the ACR phantom is {np.round(rot_ang, 3)} degrees, which '
                            f'is less than the recommended 3 degrees. Results will be unreliable!')
 
-        mtf_dcm = self.ACR_obj.dcm[0]
+        mtf_dcm = self.ACR_obj.dcms[0]
+
+        # Initialise results dictionary
+        results = self.init_result_dict()
+        results['file'] = self.img_desc(mtf_dcm)
 
         try:
             raw_res, fitted_res = self.get_mtf50(mtf_dcm)
-            mtf_results[f"estimated_rotation_angle_{self.key(mtf_dcm)}"] = rot_ang
-            mtf_results[f"raw_mtf50_{self.key(mtf_dcm)}"] = raw_res
-            mtf_results[f"fitted_mtf50_{self.key(mtf_dcm)}"] = fitted_res
+            results['measurement'] = {
+                "estimated rotation angle": round(rot_ang, 2),
+                "raw mtf50": round(raw_res, 2),
+                "fitted mtf50": round(fitted_res, 2)
+            }
         except Exception as e:
-            print(f"Could not calculate the spatial resolution for {self.key(mtf_dcm)} because of : {e}")
+            print(f"Could not calculate the spatial resolution for {self.img_desc(mtf_dcm)} because of : {e}")
             traceback.print_exc(file=sys.stdout)
-
-        results = {self.key(self.dcm_list[0]): mtf_results}
 
         # only return reports if requested
         if self.report:
-            results['report_images'] = self.report_files
+            results['report_image'] = self.report_files
 
         return results
 
@@ -268,8 +271,8 @@ class ACRSpatialResolution(HazenTask):
         freq, lsf_raw, MTF_raw = self.calculate_MTF(erf, res)
         _, lsf_fit, MTF_fit = self.calculate_MTF(erf_fit, res)
 
-        eff_raw_res = round(self.identify_MTF50(freq, MTF_raw), 2)
-        eff_fit_res = round(self.identify_MTF50(freq, MTF_fit), 2)
+        eff_raw_res = self.identify_MTF50(freq, MTF_raw)
+        eff_fit_res = self.identify_MTF50(freq, MTF_fit)
 
         if self.report:
             edge_loc = self.edge_location_for_plot(crop_img, edge_type)
@@ -321,7 +324,8 @@ class ACRSpatialResolution(HazenTask):
             axes[4].legend(fancybox='true')
             axes[4].set_title('MTF', fontsize=14)
 
-            img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(dcm)}.png'))
+            img_path = os.path.realpath(os.path.join(
+                self.report_path, f'{self.img_desc(dcm)}.png'))
             fig.savefig(img_path)
             self.report_files.append(img_path)
 

--- a/hazenlib/tasks/acr_spatial_resolution.py
+++ b/hazenlib/tasks/acr_spatial_resolution.py
@@ -56,7 +56,7 @@ class ACRSpatialResolution(HazenTask):
 
     def run(self) -> dict:
         mtf_results = {}
-        self.ACR_obj = ACRObject(self.data)
+        self.ACR_obj = ACRObject(self.dcm_list)
         rot_ang = self.ACR_obj.rot_angle
 
         if np.round(np.abs(rot_ang), 2) < 3:
@@ -74,7 +74,7 @@ class ACRSpatialResolution(HazenTask):
             print(f"Could not calculate the spatial resolution for {self.key(mtf_dcm)} because of : {e}")
             traceback.print_exc(file=sys.stdout)
 
-        results = {self.key(self.data[0]): mtf_results}
+        results = {self.key(self.dcm_list[0]): mtf_results}
 
         # only return reports if requested
         if self.report:

--- a/hazenlib/tasks/acr_uniformity.py
+++ b/hazenlib/tasks/acr_uniformity.py
@@ -46,7 +46,7 @@ class ACRUniformity(HazenTask):
 
         # only return reports if requested
         if self.report:
-            results['reports'] = {'images': self.report_files}
+            results['report_images'] = self.report_files
 
         return results
 

--- a/hazenlib/tasks/acr_uniformity.py
+++ b/hazenlib/tasks/acr_uniformity.py
@@ -32,7 +32,7 @@ class ACRUniformity(HazenTask):
         self.ACR_obj = None
 
     def run(self) -> dict:
-        results = {}
+        results = self.init_result_dict()
         self.ACR_obj = ACRObject(self.data)
         uniformity_dcm = self.ACR_obj.dcm[6]
 

--- a/hazenlib/tasks/acr_uniformity.py
+++ b/hazenlib/tasks/acr_uniformity.py
@@ -29,24 +29,30 @@ class ACRUniformity(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.ACR_obj = None
 
     def run(self) -> dict:
-        results = self.init_result_dict()
+        # Initialise ACR object
         self.ACR_obj = ACRObject(self.dcm_list)
-        uniformity_dcm = self.ACR_obj.dcm[6]
+        uniformity_dcm = self.ACR_obj.dcms[6]
+
+        # Initialise results dictionary
+        results = self.init_result_dict()
+        results['file'] = self.img_desc(uniformity_dcm)
 
         try:
             result = self.get_integral_uniformity(uniformity_dcm)
-            results[self.key(uniformity_dcm)] = result
+            results['measurement'] = {
+                "integral uniformity %": round(result, 2)
+                }
         except Exception as e:
             print(
-                f"Could not calculate the percent integral uniformity for {self.key(uniformity_dcm)} because of : {e}")
+                f"Could not calculate the percent integral uniformity for"
+                f"{self.img_desc(uniformity_dcm)} because of : {e}")
             traceback.print_exc(file=sys.stdout)
 
         # only return reports if requested
         if self.report:
-            results['report_images'] = self.report_files
+            results['report_image'] = self.report_files
 
         return results
 
@@ -103,7 +109,6 @@ class ACRUniformity(HazenTask):
 
         piu = 100 * (1 - (sig_max - sig_min) / (sig_max + sig_min))
 
-        piu = np.round(piu, 2)
         if self.report:
             import matplotlib.pyplot as plt
             fig, axes = plt.subplots(2, 1)
@@ -128,7 +133,8 @@ class ACRUniformity(HazenTask):
             axes[1].axis('off')
             axes[1].set_title('Percent Integral Uniformity = ' + str(np.round(piu, 2)) + '%')
 
-            img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(dcm)}.png'))
+            img_path = os.path.realpath(os.path.join(
+                self.report_path, f'{self.img_desc(dcm)}.png'))
             fig.savefig(img_path)
             self.report_files.append(img_path)
 

--- a/hazenlib/tasks/acr_uniformity.py
+++ b/hazenlib/tasks/acr_uniformity.py
@@ -33,7 +33,7 @@ class ACRUniformity(HazenTask):
 
     def run(self) -> dict:
         results = self.init_result_dict()
-        self.ACR_obj = ACRObject(self.data)
+        self.ACR_obj = ACRObject(self.dcm_list)
         uniformity_dcm = self.ACR_obj.dcm[6]
 
         try:

--- a/hazenlib/tasks/ghosting.py
+++ b/hazenlib/tasks/ghosting.py
@@ -28,7 +28,7 @@ class Ghosting(HazenTask):
 
         # only return reports if requested
         if self.report:
-            results['reports'] = {'images': self.report_files}
+            results['report_images'] = self.report_files
 
         return results
 

--- a/hazenlib/tasks/ghosting.py
+++ b/hazenlib/tasks/ghosting.py
@@ -195,7 +195,7 @@ class Ghosting(HazenTask):
         )
         return ghost_slice
 
-    def get_ghosting(self, dcm) -> dict:
+    def get_ghosting(self, dcm) -> float:
 
         bbox = self.get_signal_bounding_box(dcm.pixel_array)
 

--- a/hazenlib/tasks/ghosting.py
+++ b/hazenlib/tasks/ghosting.py
@@ -15,16 +15,14 @@ class Ghosting(HazenTask):
         super().__init__(**kwargs)
 
     def run(self) -> dict:
-        ghosting_results = {}
+        results = self.init_result_dict()
         key = self.key(self.single_dcm, properties=['SeriesDescription', 'EchoTime', 'NumberOfAverages'])
         try:
-            fig, ghosting_results[key] = self.get_ghosting(self.single_dcm)
+            fig, results[key] = self.get_ghosting(self.single_dcm)
 
         except Exception as e:
             print(f"Could not calculate the ghosting for {key} because of : {e}")
             traceback.print_exc(file=sys.stdout)
-
-        results = {'ghosting_results': ghosting_results}
 
         # only return reports if requested
         if self.report:

--- a/hazenlib/tasks/ghosting.py
+++ b/hazenlib/tasks/ghosting.py
@@ -16,17 +16,21 @@ class Ghosting(HazenTask):
 
     def run(self) -> dict:
         results = self.init_result_dict()
-        key = self.key(self.single_dcm, properties=['SeriesDescription', 'EchoTime', 'NumberOfAverages'])
+        img_desc = self.img_desc(self.single_dcm,
+                        properties=['SeriesDescription', 'EchoTime', 'NumberOfAverages'])
+        results['file'] = img_desc
+
         try:
-            fig, results[key] = self.get_ghosting(self.single_dcm)
+            ghosting_value = self.get_ghosting(self.single_dcm)
+            results['measurement'] = {"ghosting %": round(ghosting_value, 3)}
 
         except Exception as e:
-            print(f"Could not calculate the ghosting for {key} because of : {e}")
+            print(f"Could not calculate the ghosting for {img_desc} because of : {e}")
             traceback.print_exc(file=sys.stdout)
 
         # only return reports if requested
         if self.report:
-            results['report_images'] = self.report_files
+            results['report_image'] = self.report_files
 
         return results
 
@@ -247,11 +251,10 @@ class Ghosting(HazenTask):
 
             ax.imshow(img)
             # fig.savefig(f'{self.report_path}.png')
-            img_path = os.path.realpath(os.path.join(self.report_path,
-                                                     f"{self.key(dcm, properties=['SeriesDescription', 'EchoTime', 'NumberOfAverages'])}.png"))
+            img_path = os.path.realpath(os.path.join(
+                self.report_path,
+                f"{self.img_desc(dcm, properties=['SeriesDescription', 'EchoTime', 'NumberOfAverages'])}.png"))
             fig.savefig(img_path)
             self.report_files.append(img_path)
 
-            return fig, ghosting
-
-        return None, ghosting
+        return ghosting

--- a/hazenlib/tasks/ghosting.py
+++ b/hazenlib/tasks/ghosting.py
@@ -13,6 +13,7 @@ class Ghosting(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.single_dcm = self.dcm_list[0]
 
     def run(self) -> dict:
         results = self.init_result_dict()

--- a/hazenlib/tasks/ghosting.py
+++ b/hazenlib/tasks/ghosting.py
@@ -16,15 +16,13 @@ class Ghosting(HazenTask):
 
     def run(self) -> dict:
         ghosting_results = {}
-        for dcm in self.data:
-            key = self.key(dcm, properties=['SeriesDescription', 'EchoTime', 'NumberOfAverages'])
-            try:
-                fig, ghosting_results[key] = self.get_ghosting(dcm)
+        key = self.key(self.single_dcm, properties=['SeriesDescription', 'EchoTime', 'NumberOfAverages'])
+        try:
+            fig, ghosting_results[key] = self.get_ghosting(self.single_dcm)
 
-            except Exception as e:
-                print(f"Could not calculate the ghosting for {key} because of : {e}")
-                traceback.print_exc(file=sys.stdout)
-                continue
+        except Exception as e:
+            print(f"Could not calculate the ghosting for {key} because of : {e}")
+            traceback.print_exc(file=sys.stdout)
 
         results = {'ghosting_results': ghosting_results}
 

--- a/hazenlib/tasks/relaxometry.py
+++ b/hazenlib/tasks/relaxometry.py
@@ -214,7 +214,7 @@ class Relaxometry(HazenTask):
         relax_str = calc.lower()
 
         if calc in ['T1', 't1']:
-            image_stack = T1ImageStack(self.data)
+            image_stack = T1ImageStack(self.dcm_list)
             try:
                 template_dcm = pydicom.read_file(
                     TEMPLATE_VALUES[f'plate{plate_number}'][relax_str]['filename'])
@@ -223,7 +223,7 @@ class Relaxometry(HazenTask):
                     f' Please pass plate number as arg.')
                 exit()
         elif calc in ['T2', 't2']:
-            image_stack = T2ImageStack(self.data)
+            image_stack = T2ImageStack(self.dcm_list)
             try:
                 template_dcm = pydicom.read_file(
                     TEMPLATE_VALUES[f'plate{plate_number}'][relax_str]['filename'])

--- a/hazenlib/tasks/relaxometry.py
+++ b/hazenlib/tasks/relaxometry.py
@@ -254,12 +254,15 @@ class Relaxometry(HazenTask):
         frac_time = frac_time_diff[:-1]
         RMS_frac_error = np.sqrt(np.mean(np.square(frac_time)))
 
-        # Generate output dict
-        index_im = image_stack.images[0]
-        output_key = f"{index_im.SeriesDescription}_{index_im.SeriesNumber}_{index_im.InstanceNumber}_" \
-                    f"P{plate_number}_{relax_str}"
+        # Generate results dict
+        index_im = self.dcm_list[0]
+        results = self.init_result_dict()
+        output_key = '_'.join([self.img_desc(index_im), str(plate_number), relax_str])
+        results['file'] = output_key
 
-        relax_result = {'rms_frac_time_difference' : RMS_frac_error}
+        results['measurement'] = {
+            'rms_frac_time_difference' : round(RMS_frac_error, 3)
+        }
 
         if self.report:
             img_path = os.path.join(self.report_path, output_key)
@@ -326,7 +329,7 @@ class Relaxometry(HazenTask):
                 calc_times=image_stack.relax_times,
                 frac_time_difference=frac_time_diff.tolist())
             # , output_graphics=output_files_path
-            relax_result.update(metadata)
+            results['metadata'] = metadata
 
             detailed_output['measurement details'] = {
                 'Echo Time': [im.EchoTime for im in image_stack.images],
@@ -346,12 +349,11 @@ class Relaxometry(HazenTask):
             self.report_files.append(
                 ('further_details', detailed_outpath))
 
-        result = {output_key: relax_result}
         if self.report:
-            result['report_images'] = self.report_files
+            results['report_image'] = self.report_files
 
         # plt.show()
-        return result
+        return results
 
 
 def outline_mask(im):

--- a/hazenlib/tasks/relaxometry.py
+++ b/hazenlib/tasks/relaxometry.py
@@ -348,7 +348,7 @@ class Relaxometry(HazenTask):
 
         result = {output_key: relax_result}
         if self.report:
-            result['images'] = self.report_files
+            result['report_images'] = self.report_files
 
         # plt.show()
         return result

--- a/hazenlib/tasks/slice_position.py
+++ b/hazenlib/tasks/slice_position.py
@@ -27,7 +27,7 @@ class SlicePosition(HazenTask):
         if len(self.dcm_list) != 60:
             raise Exception('Need 60 DICOM')
 
-        slice_data = copy.deepcopy(self.data)
+        slice_data = copy.deepcopy(self.dcm_list)
         slice_data.sort(key=lambda x: x.SliceLocation)  # sort by slice location
 
         truncated_data = slice_data[10:50]  # ignore first and last 10 dicom
@@ -42,7 +42,7 @@ class SlicePosition(HazenTask):
         result = [str(abs(decimal.Decimal(i) * 1)) for i in result]
         del decimal
 
-        results = {self.key(self.data[0]): {'slice_positions': result}}
+        results = {self.key(self.dcm_list[0]): {'slice_positions': result}}
 
         # only return reports if requested
         if self.report:
@@ -229,20 +229,20 @@ class SlicePosition(HazenTask):
             plt.xlabel('slice position [slice number]')
             plt.ylabel('Slice position error [mm]')
 
-            img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(self.data[0])}_slice_position.png'))
+            img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(self.dcm_list[0])}_slice_position.png'))
             fig.savefig(img_path)
             self.report_files.append(img_path)
 
             # fig, ax = plt.subplots(1, 1)
             # for i, pos in enumerate(nominal_positions):
             #     ax.cla()
-            #     dcm = self.data[i+10]
+            #     dcm = self.dcm_list[i+10]
             #     ax.imshow(dcm.pixel_array, cmap='gray')
             #     rods_x = [left_rod["x_pos"][i], right_rod['x_pos'][i]]
             #     rods_y = [left_rod["y_pos"][i], right_rod['y_pos'][i]]
             #     ax.scatter(rods_x, rods_y, 20, c='green', marker='+')
             #
-            #     img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(self.data[0])}_{i}_slice_position.png'))
+            #     img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(self.dcm_listdcm_list[0])}_{i}_slice_position.png'))
             #     plt.savefig(img_path)
             #     self.report_files.append(img_path)
 

--- a/hazenlib/tasks/slice_position.py
+++ b/hazenlib/tasks/slice_position.py
@@ -24,7 +24,7 @@ class SlicePosition(HazenTask):
         super().__init__(**kwargs)
 
     def run(self) -> dict:
-        if len(self.data) != 60:
+        if len(self.dcm_list) != 60:
             raise Exception('Need 60 DICOM')
 
         slice_data = copy.deepcopy(self.data)

--- a/hazenlib/tasks/slice_position.py
+++ b/hazenlib/tasks/slice_position.py
@@ -29,9 +29,10 @@ class SlicePosition(HazenTask):
 
         slice_data = copy.deepcopy(self.dcm_list)
         slice_data.sort(key=lambda x: x.SliceLocation)  # sort by slice location
-
         truncated_data = slice_data[10:50]  # ignore first and last 10 dicom
+
         results = self.init_result_dict()
+        results['file'] = self.img_desc(truncated_data[18])
 
         try:
             position_errors = self.slice_position_error(truncated_data)
@@ -40,16 +41,14 @@ class SlicePosition(HazenTask):
             max_pos = round(np.max(position_errors), 2)
             avg_pos = round(np.mean(position_errors), 2)
 
-            result = {'maximum': max_pos, 'average': avg_pos}
+            results['measurement'] = {
+                'maximum mm': max_pos, 'average mm': avg_pos}
         except Exception as e:
             raise
 
-
-        results[self.key(self.dcm_list[0])] = result
-
         # only return reports if requested
         if self.report:
-            results['report_images'] = self.report_files
+            results['report_image'] = self.report_files
 
         return results
 
@@ -233,7 +232,8 @@ class SlicePosition(HazenTask):
             plt.xlabel('slice position [slice number]')
             plt.ylabel('Slice position error [mm]')
 
-            img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(self.dcm_list[0])}_slice_position.png'))
+            img_path = os.path.realpath(os.path.join(
+                self.report_path, f'{self.img_desc(self.dcm_list[0])}_slice_position.png'))
             fig.savefig(img_path)
             self.report_files.append(img_path)
 

--- a/hazenlib/tasks/slice_position.py
+++ b/hazenlib/tasks/slice_position.py
@@ -46,7 +46,7 @@ class SlicePosition(HazenTask):
 
         # only return reports if requested
         if self.report:
-            results['reports'] = {'images': self.report_files}
+            results['report_images'] = self.report_files
 
         return results
 

--- a/hazenlib/tasks/slice_position.py
+++ b/hazenlib/tasks/slice_position.py
@@ -209,10 +209,11 @@ class SlicePosition(HazenTask):
         # Correct for zero offset
         nominal_positions = [x - nominal_positions[18] + z_length_mm[18] for x in nominal_positions]
         positions = np.subtract(z_length_mm, nominal_positions)
+        distances = [abs(x) for x in positions]
 
         # Round calculated values to the appropriate decimal places
-        max_pos = round(np.max(positions), 2)
-        avg_pos = round(np.mean(positions), 2)
+        max_pos = round(np.max(distances), 2)
+        avg_pos = round(np.mean(distances), 2)
 
         if self.report:
             import matplotlib.pyplot as plt

--- a/hazenlib/tasks/slice_position.py
+++ b/hazenlib/tasks/slice_position.py
@@ -34,7 +34,13 @@ class SlicePosition(HazenTask):
         results = self.init_result_dict()
 
         try:
-            result = self.slice_position_error(truncated_data)
+            position_errors = self.slice_position_error(truncated_data)
+
+            # Round calculated values to the appropriate decimal places
+            max_pos = round(np.max(position_errors), 2)
+            avg_pos = round(np.mean(position_errors), 2)
+
+            result = {'maximum': max_pos, 'average': avg_pos}
         except Exception as e:
             raise
 
@@ -211,10 +217,6 @@ class SlicePosition(HazenTask):
         positions = np.subtract(z_length_mm, nominal_positions)
         distances = [abs(x) for x in positions]
 
-        # Round calculated values to the appropriate decimal places
-        max_pos = round(np.max(distances), 2)
-        avg_pos = round(np.mean(distances), 2)
-
         if self.report:
             import matplotlib.pyplot as plt
             fig, ax = plt.subplots(2, 1)
@@ -248,4 +250,4 @@ class SlicePosition(HazenTask):
             #     plt.savefig(img_path)
             #     self.report_files.append(img_path)
 
-        return {'maximum': max_pos, 'average': avg_pos}
+        return distances

--- a/hazenlib/tasks/slice_width.py
+++ b/hazenlib/tasks/slice_width.py
@@ -25,6 +25,8 @@ class SliceWidth(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.pixel_size = self.single_dcm.PixelSpacing[0]
+
 
     def run(self):
         results = self.init_result_dict()
@@ -50,12 +52,11 @@ class SliceWidth(HazenTask):
         upper_row = sorted(upper_row, key=lambda rod: rod.x)
         return lower_row + middle_row + upper_row
 
-    def get_rods(self, dcm):
+    def get_rods(self, arr):
         """
         Parameters
         ----------
-        dcm : array_like
-            input DICOM file
+        arr : DICOM pixel array
         Returns
         -------
         rods : array_like – centroid coordinates of rods
@@ -68,8 +69,6 @@ class SliceWidth(HazenTask):
             456
             123
         """
-
-        arr = dcm.pixel_array
 
         # inverted image for fitting (maximisation)
         arr_inv = np.invert(arr)
@@ -213,20 +212,21 @@ class SliceWidth(HazenTask):
             horizontal and vertical distances between rods in pixels
 
         """
+        horz_dist = [
+            np.sqrt(np.square((rods[2].y - rods[0].y)) + np.square(rods[2].x - rods[0].x)),
+            np.sqrt(np.square((rods[5].y - rods[3].y)) + np.square(rods[5].x - rods[3].x)),
+            np.sqrt(np.square((rods[8].y - rods[6].y)) + np.square(rods[8].x - rods[6].x))
+            ]
 
-        horz_dist = [None] * 3
-        vert_dist = [None] * 3
-        horz_dist[0] = round((((rods[2].y - rods[0].y) ** 2) + (rods[2].x - rods[0].x) ** 2) ** 0.5, 3)
-        horz_dist[1] = round((((rods[5].y - rods[3].y) ** 2) + (rods[5].x - rods[3].x) ** 2) ** 0.5, 3)
-        horz_dist[2] = round((((rods[8].y - rods[6].y) ** 2) + (rods[8].x - rods[6].x) ** 2) ** 0.5, 3)
-
-        vert_dist[2] = round((((rods[2].y - rods[8].y) ** 2) + (rods[2].x - rods[8].x) ** 2) ** 0.5, 3)
-        vert_dist[1] = round((((rods[1].y - rods[7].y) ** 2) + (rods[1].x - rods[7].x) ** 2) ** 0.5, 3)
-        vert_dist[0] = round((((rods[0].y - rods[6].y) ** 2) + (rods[0].x - rods[6].x) ** 2) ** 0.5, 3)
+        vert_dist = [
+            np.sqrt(np.square((rods[0].y - rods[6].y)) + np.square(rods[0].x - rods[6].x)),
+            np.sqrt(np.square((rods[1].y - rods[7].y)) + np.square(rods[1].x - rods[7].x)),
+            np.sqrt(np.square((rods[2].y - rods[8].y)) + np.square(rods[2].x - rods[8].x)),
+        ]
 
         return horz_dist, vert_dist
 
-    def get_rod_distortion_correction_coefficients(self, horizontal_distances, pixel_size) -> dict:
+    def get_rod_distortion_correction_coefficients(self, horizontal_distances) -> dict:
         """
         Removes the effect of geometric distortion from the slice width measurement. Assumes that rod separation is
         120 mm.
@@ -236,28 +236,24 @@ class SliceWidth(HazenTask):
         horizontal_distances : list
             horizontal distances between rods, in pixels
 
-        pixel_size : float
-            pixel size as defined in DICOM header
-
         Returns
         -------
         coefficients : dict
             dictionary containing top and bottom distortion corrections, in mm
         """
 
-        coefficients = {"top": round(np.mean(horizontal_distances[1:3]) * pixel_size / 120, 4),
-                        "bottom": round(np.mean(horizontal_distances[0:2]) * pixel_size / 120, 4)}
+        coefficients = {"top": np.mean(horizontal_distances[1:3]) * self.pixel_size / 120,
+                        "bottom": np.mean(horizontal_distances[0:2]) * self.pixel_size / 120}
 
         return coefficients
 
-    def get_rod_distortions(self, rods, dcm):
-
+    def get_rod_distortions(self, horz_dist, vert_dist):
         """
 
         Parameters
         ----------
-        rods
-        dcm
+        horizontal distances
+        vertical distances
 
         Returns
         -------
@@ -265,13 +261,9 @@ class SliceWidth(HazenTask):
             horizontal and vertical distortion values, in mm
         """
 
-        pixel_spacing = dcm.PixelSpacing[0]
-        horz_dist, vert_dist = self.get_rod_distances(rods)
-
         # calculate the horizontal and vertical distances
-
-        horz_dist_mm = np.multiply(pixel_spacing, horz_dist)
-        vert_dist_mm = np.multiply(pixel_spacing, vert_dist)
+        horz_dist_mm = np.multiply(self.pixel_size, horz_dist)
+        vert_dist_mm = np.multiply(self.pixel_size, vert_dist)
 
         horz_distortion = 100 * np.std(horz_dist_mm, ddof=1) / np.mean(horz_dist_mm)  # ddof to match MATLAB std
         vert_distortion = 100 * np.std(vert_dist_mm, ddof=1) / np.mean(vert_dist_mm)
@@ -474,7 +466,7 @@ class SliceWidth(HazenTask):
 
         return trap, fwhm
 
-    def get_ramp_profiles(self, image_array, rods, pixel_size) -> dict:
+    def get_ramp_profiles(self, image_array, rods) -> dict:
         """
         Find the central y-axis point for the top and bottom profiles
         done by finding the distance between the mid-distances of the central rods
@@ -483,12 +475,9 @@ class SliceWidth(HazenTask):
         ----------
         image_array
         rods
-        pixel_size
 
         Returns
         -------
-
-
         """
 
         top_profile_vertical_centre = np.round(((rods[3].y - rods[6].y) / 2) + rods[6].y).astype(int)
@@ -496,13 +485,13 @@ class SliceWidth(HazenTask):
 
         # Selected 20mm around the mid-distances and take the average to find the line profiles
         top_profile = image_array[
-                      (top_profile_vertical_centre - round(10 / pixel_size)):(
-                                  top_profile_vertical_centre + round(10 / pixel_size)),
+                      (top_profile_vertical_centre - round(10 / self.pixel_size)):(
+                                  top_profile_vertical_centre + round(10 / self.pixel_size)),
                       int(rods[3].x):int(rods[5].x)]
 
         bottom_profile = image_array[
-                         (bottom_profile_vertical_centre - round(10 / pixel_size)):(
-                                     bottom_profile_vertical_centre + round(10 / pixel_size)),
+                         (bottom_profile_vertical_centre - round(10 / self.pixel_size)):(
+                                     bottom_profile_vertical_centre + round(10 / self.pixel_size)),
                          int(rods[3].x):int(rods[5].x)]
 
         return {"top": top_profile, "bottom": bottom_profile,
@@ -586,7 +575,7 @@ class SliceWidth(HazenTask):
 
         cont = 1
         j = 0
-        """Go through a series of changes to reduce error, if error doesnt reduced in one entire loop then exit"""
+        """Go through a series of changes to reduce error, if error doesn't reduced in one entire loop then exit"""
         while cont == 1:
             j += 1
             cont = 0
@@ -676,15 +665,16 @@ class SliceWidth(HazenTask):
         slice_width_mm = {"top": {}, "bottom": {}, "combined": {}}
         arr = dcm.pixel_array
         sample_spacing = 0.25
-        pixel_size = dcm.PixelSpacing[0]
 
-        rods, rods_initial = self.get_rods(dcm)
+        rods, rods_initial = self.get_rods(arr)
         horz_distances, vert_distances = self.get_rod_distances(rods)
-        horz_distortion_mm, vert_distortion_mm = self.get_rod_distortions(rods, dcm)
-        correction_coefficients_mm = self.get_rod_distortion_correction_coefficients(horizontal_distances=horz_distances,
-                                                                                pixel_size=pixel_size)
+        horz_distortion_mm, vert_distortion_mm = self.get_rod_distortions(
+            horz_distances, vert_distances
+            )
+        correction_coefficients_mm = self.get_rod_distortion_correction_coefficients(
+            horizontal_distances=horz_distances)
 
-        ramp_profiles = self.get_ramp_profiles(arr, rods, pixel_size)
+        ramp_profiles = self.get_ramp_profiles(arr, rods)
         ramp_profiles_baseline_corrected = {"top": self.baseline_correction(np.mean(ramp_profiles["top"], axis=0),
                                                                        sample_spacing),
                                             "bottom": self.baseline_correction(np.mean(ramp_profiles["bottom"], axis=0),
@@ -694,34 +684,34 @@ class SliceWidth(HazenTask):
                                                                       dcm.SliceThickness)
         top_trap, fwhm = self.trapezoid(*trapezoid_coefficients)
 
-        slice_width_mm["top"]["default"] = fwhm * sample_spacing * pixel_size * np.tan((11.3 * pi) / 180)
+        slice_width_mm["top"]["default"] = fwhm * sample_spacing * self.pixel_size * np.tan((11.3 * pi) / 180)
         # Factor of 4 because interpolated by factor of four
 
         slice_width_mm["top"]["geometry_corrected"] = slice_width_mm["top"]["default"] / correction_coefficients_mm[
             "top"]
 
         # AAPM method directly incorporating phantom tilt
-        slice_width_mm["top"]["aapm"] = fwhm * sample_spacing * pixel_size
+        slice_width_mm["top"]["aapm"] = fwhm * sample_spacing * self.pixel_size
 
         # AAPM method directly incorporating phantom tilt and independent of geometric linearity
-        slice_width_mm["top"]["aapm_corrected"] = (fwhm * sample_spacing * pixel_size) / correction_coefficients_mm[
+        slice_width_mm["top"]["aapm_corrected"] = (fwhm * sample_spacing * self.pixel_size) / correction_coefficients_mm[
             "top"]
 
         trapezoid_coefficients, baseline_coefficients = self.fit_trapezoid(ramp_profiles_baseline_corrected["bottom"],
                                                                       dcm.SliceThickness)
         bottom_trap, fwhm = self.trapezoid(*trapezoid_coefficients)
 
-        slice_width_mm["bottom"]["default"] = fwhm * sample_spacing * pixel_size * np.tan((11.3 * pi) / 180)
+        slice_width_mm["bottom"]["default"] = fwhm * sample_spacing * self.pixel_size * np.tan((11.3 * pi) / 180)
         # Factor of 4 because interpolated by factor of four
 
         slice_width_mm["bottom"]["geometry_corrected"] = slice_width_mm["bottom"]["default"] / \
                                                          correction_coefficients_mm["bottom"]
 
         # AAPM method directly incorporating phantom tilt
-        slice_width_mm["bottom"]["aapm"] = fwhm * sample_spacing * pixel_size
+        slice_width_mm["bottom"]["aapm"] = fwhm * sample_spacing * self.pixel_size
 
         # AAPM method directly incorporating phantom tilt and independent of geometric linearity
-        slice_width_mm["bottom"]["aapm_corrected"] = (fwhm * sample_spacing * pixel_size) / correction_coefficients_mm[
+        slice_width_mm["bottom"]["aapm_corrected"] = (fwhm * sample_spacing * self.pixel_size) / correction_coefficients_mm[
             "bottom"]
 
         # Geometric mean of slice widths (pg 34 of IPEM Report 80)
@@ -767,14 +757,14 @@ class SliceWidth(HazenTask):
 
         # calculate linearity in mm from distances in pixels
 
-        horizontal_linearity_mm = np.mean(horz_distances) * pixel_size
-        vertical_linearity_mm = np.mean(vert_distances) * pixel_size
+        horizontal_linearity_mm = np.mean(horz_distances) * self.pixel_size
+        vertical_linearity_mm = np.mean(vert_distances) * self.pixel_size
 
         # calculate horizontal and vertical distances in mm from distances in pixels, for output
 
-        horz_distances_mm = [x * pixel_size for x in horz_distances]
+        horz_distances_mm = [round(x * self.pixel_size, 3) for x in horz_distances]
 
-        vert_distances_mm = [x * pixel_size for x in vert_distances]
+        vert_distances_mm = [round(x * self.pixel_size, 3) for x in vert_distances]
 
         if self.report:
             import matplotlib.pyplot as plt
@@ -831,8 +821,17 @@ class SliceWidth(HazenTask):
         # slice_width['top']['default']}\n" f"Slice width bottom (mm): {slice_width['bottom']['default']}\nPhantom tilt (
         # deg): {phantom_tilt_deg}\n" f"Slice width AAPM geometry corrected (mm): {slice_width['combined'][
         # 'aapm_tilt_corrected']}")
+        
+        distortion_values = {
+            "vertical mm": round(vert_distortion_mm, 2),
+            "horizontal mm": round(horz_distortion_mm, 2)
+        }
+        
+        linearity_values = {
+            "vertical mm": round(vertical_linearity_mm, 2),
+            "horizontal mm": round(horizontal_linearity_mm, 2)
+        }
 
-        return {'slice_width_mm': slice_width_mm['combined']['aapm_tilt_corrected'],
-                'vertical_distortion_mm': vert_distortion_mm, 'horizontal_distortion_mm': horz_distortion_mm,
-                'vertical_linearity_mm': vertical_linearity_mm, 'horizontal_linearity_mm': horizontal_linearity_mm,
+        return {'slice width mm': round(slice_width_mm['combined']['aapm_tilt_corrected'], 2),
+                # 'distortion values': distortion_values, 'linearity values': linearity_values,
                 'horizontal_distances_mm': horz_distances_mm, 'vertical_distances_mm': vert_distances_mm}

--- a/hazenlib/tasks/slice_width.py
+++ b/hazenlib/tasks/slice_width.py
@@ -27,18 +27,18 @@ class SliceWidth(HazenTask):
         super().__init__(**kwargs)
         self.pixel_size = self.single_dcm.PixelSpacing[0]
 
-
     def run(self):
         results = self.init_result_dict()
+        results['file'] = self.img_desc(self.single_dcm)
         try:
-            results[self.key(self.single_dcm)] = self.get_slice_width(self.single_dcm)
+            results['measurement'] = self.get_slice_width(self.single_dcm)
         except Exception as e:
-            print(f"Could not calculate the slice_width for {self.key(self.single_dcm)} because of : {e}")
+            print(f"Could not calculate the slice_width for {self.img_desc(self.single_dcm)} because of : {e}")
             traceback.print_exc(file=sys.stdout)
 
         # only return reports if requested
         if self.report:
-            results['report_images'] = self.report_files
+            results['report_image'] = self.report_files
 
         return results
 
@@ -150,9 +150,9 @@ class SliceWidth(HazenTask):
         for idx in range(len(rods)):
             cropped_data = []
             cropped_data = arr_inv[bbox["x_start"][idx]:bbox["x_end"][idx], bbox["y_start"][idx]:bbox["y_end"][idx]]
-            x0_im[idx], y0_im[idx], x0[idx], y0[idx] = self.fit_gauss_2d_to_rods(cropped_data, bbox["intensity_max"][idx],
-                                                                            bbox["rod_dia"][idx], bbox["radius"],
-                                                                            bbox["x_start"][idx], bbox["y_start"][idx])
+            x0_im[idx], y0_im[idx], x0[idx], y0[idx] = self.fit_gauss_2d_to_rods(
+                cropped_data, bbox["intensity_max"][idx], bbox["rod_dia"][idx],
+                bbox["radius"], bbox["x_start"][idx], bbox["y_start"][idx])
 
             # note: flipped x/y
             rods[idx].x = y0_im[idx]
@@ -180,7 +180,8 @@ class SliceWidth(HazenTask):
             for idx in range(len(rods)):
                 axes[2].plot(rods_initial[idx].x, rods_initial[idx].y, 'y.')
                 axes[2].plot(rods[idx].x, rods[idx].y, 'r.')
-            img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(dcm)}_rod_centroids.png'))
+            img_path = os.path.realpath(os.path.join(
+                self.report_path, f'{self.img_desc(self.single_dcm)}_rod_centroids.png'))
             fig.savefig(img_path)
             self.report_files.append(img_path)
 
@@ -801,7 +802,8 @@ class SliceWidth(HazenTask):
                 loc="center"
             )
 
-            img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(dcm)}.png'))
+            img_path = os.path.realpath(os.path.join(
+                            self.report_path, f'{self.img_desc(dcm)}.png'))
             fig.savefig(img_path)
             self.report_files.append(img_path)
 
@@ -829,4 +831,4 @@ class SliceWidth(HazenTask):
 
         return {'slice width mm': round(slice_width_mm['combined']['aapm_tilt_corrected'], 2),
                 'distortion values': distortion_values, 'linearity values': linearity_values,
-                'horizontal_distances_mm': horz_distances_mm, 'vertical_distances_mm': vert_distances_mm}
+                'horizontal distances mm': horz_distances_mm, 'vertical distances mm': vert_distances_mm}

--- a/hazenlib/tasks/slice_width.py
+++ b/hazenlib/tasks/slice_width.py
@@ -270,7 +270,6 @@ class SliceWidth(HazenTask):
         return horz_distortion, vert_distortion
 
     def baseline_correction(self, profile, sample_spacing):
-
         """
         Calculates quadratic fit of the baseline and subtracts from profile
 
@@ -283,7 +282,6 @@ class SliceWidth(HazenTask):
         -------
 
         """
-
         profile_width = len(profile)
         padding = 30
         outer_profile = np.concatenate([profile[0:padding], profile[-padding:]])
@@ -378,7 +376,6 @@ class SliceWidth(HazenTask):
         -------
         x0_im / y0_im : rod centroid coordinates in dimensions of original image
         x0 / y0 : rod centroid coordinates in dimensions of cropped image
-
         """
 
         # get (x,y) coordinates for fitting
@@ -424,7 +421,6 @@ class SliceWidth(HazenTask):
         return x0_im, y0_im, x0, y0
 
     def trapezoid(self, n_ramp, n_plateau, n_left_baseline, n_right_baseline, plateau_amplitude):
-
         """
 
         Parameters
@@ -509,7 +505,6 @@ class SliceWidth(HazenTask):
         -------
         trapezoid_fit_initial
         trapezoid_fit_coefficients
-
         """
 
         n_plateau, n_ramp = None, None
@@ -537,7 +532,6 @@ class SliceWidth(HazenTask):
         return trapezoid_fit_initial, trapezoid_fit_coefficients
 
     def fit_trapezoid(self, profiles, slice_thickness):
-
         """
 
         Parameters
@@ -575,7 +569,8 @@ class SliceWidth(HazenTask):
 
         cont = 1
         j = 0
-        """Go through a series of changes to reduce error, if error doesn't reduced in one entire loop then exit"""
+        # Go through a series of changes to reduce error,
+        # if error doesn't reduced in one entire loop then exit
         while cont == 1:
             j += 1
             cont = 0
@@ -833,5 +828,5 @@ class SliceWidth(HazenTask):
         }
 
         return {'slice width mm': round(slice_width_mm['combined']['aapm_tilt_corrected'], 2),
-                # 'distortion values': distortion_values, 'linearity values': linearity_values,
+                'distortion values': distortion_values, 'linearity values': linearity_values,
                 'horizontal_distances_mm': horz_distances_mm, 'vertical_distances_mm': vert_distances_mm}

--- a/hazenlib/tasks/slice_width.py
+++ b/hazenlib/tasks/slice_width.py
@@ -36,7 +36,7 @@ class SliceWidth(HazenTask):
 
         # only return reports if requested
         if self.report:
-            results['reports'] = {'images': self.report_files}
+            results['report_images'] = self.report_files
 
         return results
 

--- a/hazenlib/tasks/slice_width.py
+++ b/hazenlib/tasks/slice_width.py
@@ -28,13 +28,11 @@ class SliceWidth(HazenTask):
 
     def run(self):
         results = {}
-        for dcm in self.data:
-            try:
-                results[self.key(dcm)] = self.get_slice_width(dcm)
-            except Exception as e:
-                print(f"Could not calculate the slice_width for {self.key(dcm)} because of : {e}")
-                traceback.print_exc(file=sys.stdout)
-                continue
+        try:
+            results[self.key(self.single_dcm)] = self.get_slice_width(self.single_dcm)
+        except Exception as e:
+            print(f"Could not calculate the slice_width for {self.key(self.single_dcm)} because of : {e}")
+            traceback.print_exc(file=sys.stdout)
 
         # only return reports if requested
         if self.report:

--- a/hazenlib/tasks/slice_width.py
+++ b/hazenlib/tasks/slice_width.py
@@ -27,7 +27,7 @@ class SliceWidth(HazenTask):
         super().__init__(**kwargs)
 
     def run(self):
-        results = {}
+        results = self.init_result_dict()
         try:
             results[self.key(self.single_dcm)] = self.get_slice_width(self.single_dcm)
         except Exception as e:

--- a/hazenlib/tasks/slice_width.py
+++ b/hazenlib/tasks/slice_width.py
@@ -25,6 +25,7 @@ class SliceWidth(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.single_dcm = self.dcm_list[0]
         self.pixel_size = self.single_dcm.PixelSpacing[0]
 
     def run(self):

--- a/hazenlib/tasks/snr.py
+++ b/hazenlib/tasks/snr.py
@@ -48,7 +48,7 @@ class SNR(HazenTask):
 
         # only return reports if requested
         if self.report:
-            results['reports'] = {'images': self.report_files}
+            results['report_images'] = self.report_files
 
         return results
 

--- a/hazenlib/tasks/snr.py
+++ b/hazenlib/tasks/snr.py
@@ -80,7 +80,6 @@ class SNR(HazenTask):
         return True
 
     def get_normalised_snr_factor(self, dcm: pydicom.Dataset, measured_slice_width=None) -> float:
-
         """
         Calculates SNR normalisation factor. Method matches MATLAB script.
         Utilises user provided slice_width if provided. Else finds from dcm.

--- a/hazenlib/tasks/snr.py
+++ b/hazenlib/tasks/snr.py
@@ -34,17 +34,17 @@ class SNR(HazenTask):
             measured_slice_width = float(measured_slice_width)
         snr_results = {}
 
-        if len(self.data) == 2:
-            snr, normalised_snr = self.snr_by_subtraction(self.data[0], self.data[1], measured_slice_width)
-            snr_results[f"snr_subtraction_measured_{self.key(self.data[0])}"] = round(snr, 2)
-            snr_results[f"snr_subtraction_normalised_{self.key(self.data[0])}"] = round(normalised_snr, 2)
+        if len(self.dcm_list) == 2:
+            snr, normalised_snr = self.snr_by_subtraction(self.dcm_list[0], self.dcm_list[1], measured_slice_width)
+            snr_results[f"snr_subtraction_measured_{self.key(self.dcm_list[0])}"] = round(snr, 2)
+            snr_results[f"snr_subtraction_normalised_{self.key(self.dcm_list[0])}"] = round(normalised_snr, 2)
 
-        for idx, dcm in enumerate(self.data):
+        for idx, dcm in enumerate(self.dcm_list):
             snr, normalised_snr = self.snr_by_smoothing(dcm, measured_slice_width)
             snr_results[f"snr_smoothing_measured_{self.key(dcm)}"] = round(snr, 2)
             snr_results[f"snr_smoothing_normalised_{self.key(dcm)}"] = round(normalised_snr, 2)
 
-        results = {self.key(self.data[0]): snr_results}
+        results = {self.key(self.dcm_list[0]): snr_results}
 
         # only return reports if requested
         if self.report:

--- a/hazenlib/tasks/snr_map.py
+++ b/hazenlib/tasks/snr_map.py
@@ -105,7 +105,7 @@ class SNRMap(HazenTask):
         #  =================================
         snr_map = self.calc_snr_map(original, noise)
 
-        results[key] = snr
+        results[key] = round(snr, 2)
 
         if self.report:
             #  Plot images
@@ -216,7 +216,7 @@ class SNRMap(HazenTask):
             # but using ddof=1 for consistency with IDL code.
 
         roi_snr = np.array(roi_signal) / np.array(roi_noise)
-        snr = round(roi_snr.mean(), 2)
+        snr = roi_snr.mean()
 
         logger.debug('ROIs signal=%r, noise=%r, snr=%r',
                      roi_signal, roi_noise, roi_snr)

--- a/hazenlib/tasks/snr_map.py
+++ b/hazenlib/tasks/snr_map.py
@@ -30,8 +30,6 @@ method for measurement of signal-to-noise ratio in MRI. Physics in Medicine
 """
 from hazenlib.HazenTask import HazenTask
 
-import pathlib
-
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
@@ -48,195 +46,13 @@ class SNRMap(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-    def smooth(self, kernel=skimage.morphology.square(9)):
-        """
-        Create noise and smoothed images from original_image.
-
-        Parameters
-        ----------
-        kernel : array
-            Kernel used for smoothing. Default is 9x9 boxcar.
-
-        Returns
-        -------
-        None
-        """
-        self.original_image = self.current_dcm.pixel_array.astype(float)
-        kernel = kernel / kernel.sum()  # normalise kernel
-        self.smooth_image = ndimage.filters.convolve(self.original_image, kernel)
-
-        #  Alternative method 1: OpenCV.
-        # smooth_image = cv2.blur(original_image, (kernel_len, kernel_len))
-
-        #  Alternative method 2: scipy.ndimage.
-        # kernel = np.ones([kernel_len, kernel_len], float)
-        # kernel = kernel / kernel.sum() # normalise kernel
-        # smooth_image = ndimage.filters.convolve(original_image, kernel)
-        #  Note: filters.convolve and filters.correlate produce identical output
-        #  for symetric kernels. Be careful with other kernels.
-
-        self.noise_image = self.original_image - self.smooth_image
-
-    def draw_roi_rectangles(self, ax):
-        """
-        Add ROI rectangle overlays to plot.
-
-        Parameters
-        ----------
-        ax : matplotlib.axes
-            Add the ROIs to the axes.
-
-
-        Returns
-        -------
-        None
-
-        """
-        for corner in self.roi_corners:
-            rect = patches.Rectangle(np.flip(corner), self.roi_size,
-                                     self.roi_size, linewidth=1, edgecolor='r',
-                                     facecolor='none')
-            ax.add_patch(rect)
-
-    def calc_snr_map(self):
-        """
-        Calculate SNR map from original_image and noise_image.
-        """
-        #  If you need a faster (less transparent) implementation, see:
-        #  https://nickc1.github.io/python,/matlab/2016/05/17/Standard-Deviation-(Filters)-in-Matlab-and-Python.html
-
-        noise_map = ndimage.filters.generic_filter(self.noise_image,
-                                                   lambda x: np.std(x, ddof=1),
-                                                   size=self.roi_size)
-        signal_map = ndimage.filters.uniform_filter(self.original_image,
-                                                    size=self.roi_size)
-        self.snr_map = signal_map / noise_map
-
-    def calc_snr(self):
-        """
-        Calculate SNR from original_image and noise_image.
-        """
-        roi_signal = []
-        roi_noise = []
-
-        for [x, y] in self.roi_corners:
-            roi_signal.append(self.original_image[x:x + self.roi_size, y:y + self.roi_size].mean())
-            roi_noise.append(self.noise_image[x:x + self.roi_size, y:y + self.roi_size].std(ddof=1))
-            # Note: *.std(ddof=1) uses sample standard deviation, default ddof=0
-            # uses population std dev. Not sure which is statistically correct,
-            # but using ddof=1 for consistency with IDL code.
-
-        roi_snr = np.array(roi_signal) / np.array(roi_noise)
-        self.snr = roi_snr.mean()
-
-        logger.debug('ROIs signal=%r, noise=%r, snr=%r',
-                     roi_signal, roi_noise, roi_snr)
-
-    def plot_snr_map(self, fig, ax):
-        """
-        Add SNR map to a figure axis.
-
-        Parameters
-        ----------
-        fig : figure handle
-
-        ax : axes handle within figure
-
-        Returns
-        -------
-        None
-        """
-        para_im = ax.imshow(self.snr_map, cmap='viridis', vmin=0)
-        cax = fig.add_axes([ax.get_position().x1 + 0.01,
-                            ax.get_position().y0, 0.02,
-                            ax.get_position().height])
-        plt.colorbar(para_im, cax=cax)
-        ax.set_title('SNR map')
-
-    def plot_detailed(self):
-        """
-        Create 4-image detailed SNR map plots
-
-        Returns
-        -------
-        fig : matplotlib.figure.Figure
-            Handle to plot
-        """
-        fig, axs = plt.subplots(1, 4, sharex=True, sharey=True,
-                                figsize=(8, 2.8))
-        fig.suptitle('SNR = %.2f (file: %s)'
-                     % (self.snr, os.path.basename(self.current_dcm.filename)))
-        axs[0].imshow(self.original_image, cmap='gray')
-        axs[0].set_title('Magnitude Image')
-        axs[1].imshow(self.smooth_image, cmap='gray')
-        axs[1].contour(self.mask, colors='y')
-        phantom_centre_marker = patches.Circle(
-            np.flip(np.rint(self.image_centre).astype('int')), color='y')
-        axs[1].add_patch(phantom_centre_marker)
-        axs[1].set_title('Smoothed')
-        axs[2].imshow(self.noise_image, cmap='gray')
-        axs[2].set_title('Noise')
-        self.draw_roi_rectangles(axs[0])
-        self.draw_roi_rectangles(axs[2])
-        self.plot_snr_map(fig, axs[3])
-        for ax in axs:
-            ax.axis('off')
-
-        return fig
-
-    def plot_summary(self):
-        """
-        Create 2-image summary SNR map plot.
-
-        Parameters
-        ----------
-
-
-        Returns
-        -------
-        fig : matplotlib.figure.Figure
-            Handle to plot
-
-        """
-        fig, axs = plt.subplots(1, 2, sharex=True, sharey=True,
-                                figsize=(6, 2.8))
-        axs[0].imshow(self.original_image, cmap='gray')
-        axs[0].set_title('Magnitude Image')
-
-        self.draw_roi_rectangles(axs[0])
-        self.plot_snr_map(fig, axs[1])
-        for ax in axs:
-            ax.axis('off')
-
-        return fig
-
-
-    def get_rois(self):
-        """
-        Identify phantom and generate ROI locations.
-        """
-
-        # Threshold from smooth_image to reduce noise effects
-        threshold = filters.threshold_minimum(self.smooth_image)
-        self.mask = self.smooth_image > threshold
-
-        #  Get centroid (=centre of mass for binary image) and convert to array
-        self.image_centre = \
-            np.array(ndimage.measurements.center_of_mass(self.mask))
-        logger.debug('image_centre = %r.', self.image_centre)
-
-        #  Store corner of centre ROI, cast as int for indexing
-        roi_corners = [np.rint(self.image_centre - self.roi_size / 2).astype(int)]
-
-        #  Add corners of remaining ROIs
-        roi_distance = self.roi_distance
-        roi_corners.append(roi_corners[0] + [-roi_distance, -roi_distance])
-        roi_corners.append(roi_corners[0] + [roi_distance, -roi_distance])
-        roi_corners.append(roi_corners[0] + [-roi_distance, roi_distance])
-        roi_corners.append(roi_corners[0] + [roi_distance, roi_distance])
-
-        self.roi_corners = roi_corners
+        # Initialise variables
+        self.kernel_len = 9
+        self.roi_size = 20
+        self.roi_distance = 40
+        # ----
+        # * Scale ROI distance to account for different image sizes.
+        # * Pass kernel_len and roi_size parameters from command line.
 
 
     def run(self):
@@ -251,25 +67,16 @@ class SNRMap(HazenTask):
         -------
         results : dict
         """
-        # Initialise variables
-        self.kernel_len = 9
-        self.roi_size = 20
-        self.roi_distance = 40
-
-        # ----
-        # * Scale ROI distance to account for different image sizes.
-        # * Pass kernel_len and roi_size parameters from command line.
-
         results = {}
 
-        for self.current_dcm in self.data:
+        key = self.key(self.single_dcm)
 
-            key = self.key(self.current_dcm)
+        #  Create original, smoothed and noise images
+        #  ==========================================
+        original, smoothed, noise = self.smooth(dcm=self.single_dcm,
+                                                kernel=self.kernel_len)
 
-            #  Create original, smoothed and noise images
-            #  ==========================================
-            self.smooth(skimage.morphology.square(self.kernel_len))
-
+        """
             #  Note: access NumPy arrays by column then row. E.g.
             #
             #  t=np.array([[1,2,3],[4,5,6]])
@@ -284,49 +91,255 @@ class SNRMap(HazenTask):
             #  Confusingly, patches (circles, rectangles) use traditional [x,y]
             #  positioning. To centre a circle on pixel [a,b], the circle must be
             #  centred on [b,a]. The function np.flip(coords) can help.
+        """
 
-            #  Warn if not 256 x 256 image
-            #  TODO scale distances for other image sizes
-            if self.original_image.shape != (256, 256):
-                logger.warning('Expected image size (256, 256). Image size is %r.'
-                               ' Algorithm untested with these dimensions.',
-                               self.original_image.shape)
+        #  Calculate mask and identify ROIs
+        #  =======================
+        image_centre, roi_corners = self.get_rois(smoothed)
 
-            #  Calculate mask and ROIs
-            #  =======================
-            self.get_rois()
+        #  Calculate SNR
+        #  =============
+        snr = self.calc_snr( original, noise, roi_corners)
 
-            #  Calculate SNR
-            #  =============
-            self.calc_snr()
+        #  Generate local SNR parametric map
+        #  =================================
+        snr_map = self.calc_snr_map(original, noise)
 
-            #  Generate local SNR parametric map
-            #  =================================
-            self.calc_snr_map()
+        results[key] = snr
 
+        if self.report:
             #  Plot images
             #  ===========
-            fig_detailed = self.plot_detailed()
-            fig_summary = self.plot_summary()
+            fig_detailed = self.plot_detailed(original, smoothed, noise, snr,
+                                            snr_map, image_centre, roi_corners)
+            fig_summary = self.plot_summary(snr_map, original, roi_corners)
 
             #  Save images
             #  ===========
-            if self.report:
-                detailed_image_path = os.path.join(self.report_path, f'{key}_snr_map_detailed.png')
-                summary_image_path = os.path.join(self.report_path, f'{key}_snr_map.png')
+            detailed_image_path = os.path.join(self.report_path, f'{key}_snr_map_detailed.png')
+            summary_image_path = os.path.join(self.report_path, f'{key}_snr_map.png')
 
-                fig_detailed.savefig(detailed_image_path, dpi=300)
-                fig_summary.savefig(summary_image_path, dpi=300)
+            fig_detailed.savefig(detailed_image_path, dpi=300)
+            fig_summary.savefig(summary_image_path, dpi=300)
 
-                self.report_files.append(summary_image_path)
-                self.report_files.append(detailed_image_path)
+            self.report_files.append(summary_image_path)
+            self.report_files.append(detailed_image_path)
 
-                results['reports'] = {'images': self.report_files}
-
-            results[key] = self.snr
+            results['report_images'] = self.report_files
 
         return results
 
 
+    def smooth(self, dcm, kernel: int = 9):
+        """
+        Create noise and smoothed images from original_image.
+
+        Parameters
+        ----------
+        kernel : int
+            Kernel used for smoothing. Default is 9x9 boxcar.
+
+        Returns
+        -------
+        original, smoothed and noise images
+        """
+        original_image = dcm.pixel_array.astype(float)
+
+        #  Warn if not 256 x 256 image
+        #  TODO scale distances for other image sizes
+        if original_image.shape != (256, 256):
+            logger.warning('Expected image size (256, 256). Image size is %r.'
+                            ' Algorithm untested with these dimensions.',
+                            original_image.shape)
+
+        normalised_kernel = skimage.morphology.square(kernel) / skimage.morphology.square(kernel).sum()
+        # kernel = kernel / kernel.sum()  # normalise kernel
+        smooth_image = ndimage.filters.convolve(original_image, normalised_kernel)
+
+        #  Alternative method 1: OpenCV.
+        # smooth_image = cv2.blur(original_image, (kernel_len, kernel_len))
+
+        #  Alternative method 2: scipy.ndimage.
+        # kernel = np.ones([kernel_len, kernel_len], float)
+        # kernel = kernel / kernel.sum() # normalise kernel
+        # smooth_image = ndimage.filters.convolve(original_image, kernel)
+        #  Note: filters.convolve and filters.correlate produce identical output
+        #  for symetric kernels. Be careful with other kernels.
+
+        noise_image = original_image - smooth_image
+
+        return original_image, smooth_image, noise_image
 
 
+    def get_rois(self, smooth_image):
+        """
+        Identify phantom and generate ROI locations.
+
+        Returns:
+        image_centre, roi_corners
+        """
+
+        # Threshold from smooth_image to reduce noise effects
+        threshold = filters.threshold_minimum(smooth_image)
+        self.mask = smooth_image > threshold
+
+        #  Get centroid (=centre of mass for binary image) and convert to array
+        image_centre = \
+            np.array(ndimage.measurements.center_of_mass(self.mask))
+        logger.debug('image_centre = %r.', image_centre)
+
+        #  Store corner of centre ROI, cast as int for indexing
+        roi_corners = [np.rint(image_centre - self.roi_size / 2).astype(int)]
+
+        #  Add corners of remaining ROIs
+        roi_distance = self.roi_distance
+        roi_corners.append(roi_corners[0] + [-roi_distance, -roi_distance])
+        roi_corners.append(roi_corners[0] + [roi_distance, -roi_distance])
+        roi_corners.append(roi_corners[0] + [-roi_distance, roi_distance])
+        roi_corners.append(roi_corners[0] + [roi_distance, roi_distance])
+
+        return image_centre, roi_corners
+
+
+    def calc_snr(self, original_image, noise_image, roi_corners):
+        """
+        Calculate SNR from original_image and noise_image.
+        """
+        roi_signal = []
+        roi_noise = []
+
+        for [x, y] in roi_corners:
+            roi_signal.append(original_image[x:x + self.roi_size, y:y + self.roi_size].mean())
+            roi_noise.append(noise_image[x:x + self.roi_size, y:y + self.roi_size].std(ddof=1))
+            # Note: *.std(ddof=1) uses sample standard deviation, default ddof=0
+            # uses population std dev. Not sure which is statistically correct,
+            # but using ddof=1 for consistency with IDL code.
+
+        roi_snr = np.array(roi_signal) / np.array(roi_noise)
+        snr = roi_snr.mean()
+
+        logger.debug('ROIs signal=%r, noise=%r, snr=%r',
+                     roi_signal, roi_noise, roi_snr)
+
+        return snr
+
+
+    def calc_snr_map(self, original_image, noise_image):
+        """
+        Calculate SNR map from original_image and noise_image.
+
+        Returns:
+        snr_map
+        """
+        #  If you need a faster (less transparent) implementation, see:
+        #  https://nickc1.github.io/python,/matlab/2016/05/17/Standard-Deviation-(Filters)-in-Matlab-and-Python.html
+
+        noise_map = ndimage.filters.generic_filter(noise_image,
+                            lambda x: np.std(x, ddof=1), size=self.roi_size)
+        signal_map = ndimage.filters.uniform_filter(original_image,
+                                                    size=self.roi_size)
+        snr_map = signal_map / noise_map
+
+        return snr_map
+
+
+    def draw_roi_rectangles(self, roi_corners, ax):
+        """
+        Add ROI rectangle overlays to plot.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes
+            Add the ROIs to the axes.
+
+
+        Returns
+        -------
+        None
+
+        """
+        for corner in roi_corners:
+            rect = patches.Rectangle(np.flip(corner), self.roi_size,
+                                     self.roi_size, linewidth=1, edgecolor='r',
+                                     facecolor='none')
+            ax.add_patch(rect)
+
+    def plot_snr_map(self, snr_map, fig, ax):
+        """
+        Add SNR map to a figure axis.
+
+        Parameters
+        ----------
+        fig : figure handle
+
+        ax : axes handle within figure
+
+        Returns
+        -------
+        None
+        """
+        para_im = ax.imshow(snr_map, cmap='viridis', vmin=0)
+        cax = fig.add_axes([ax.get_position().x1 + 0.01,
+                            ax.get_position().y0, 0.02,
+                            ax.get_position().height])
+        plt.colorbar(para_im, cax=cax)
+        ax.set_title('SNR map')
+
+
+    def plot_detailed(self, original_image, smooth_image, noise_image,
+                      snr, snr_map, image_centre, roi_corners):
+        """
+        Create 4-image detailed SNR map plots
+
+        Returns
+        -------
+        fig : matplotlib.figure.Figure
+            Handle to plot
+        """
+        fig, axs = plt.subplots(1, 4, sharex=True, sharey=True,
+                                figsize=(8, 2.8))
+        fig.suptitle('SNR = %.2f (file: %s)'
+                     % (snr, os.path.basename(self.single_dcm.filename)))
+        axs[0].imshow(original_image, cmap='gray')
+        axs[0].set_title('Magnitude Image')
+        axs[1].imshow(smooth_image, cmap='gray')
+        axs[1].contour(self.mask, colors='y')
+        phantom_centre_marker = patches.Circle(
+            np.flip(np.rint(image_centre).astype('int')), color='y')
+        axs[1].add_patch(phantom_centre_marker)
+        axs[1].set_title('Smoothed')
+        axs[2].imshow(noise_image, cmap='gray')
+        axs[2].set_title('Noise')
+        self.draw_roi_rectangles(roi_corners, axs[0])
+        self.draw_roi_rectangles(roi_corners, axs[2])
+        self.plot_snr_map(snr_map, fig, axs[3])
+        for ax in axs:
+            ax.axis('off')
+
+        return fig
+
+    def plot_summary(self, snr_map, original_image, roi_corners):
+        """
+        Create 2-image summary SNR map plot.
+
+        Parameters
+        ----------
+        original_image
+
+        Returns
+        -------
+        fig : matplotlib.figure.Figure
+            Handle to plot
+
+        """
+        fig, axs = plt.subplots(1, 2, sharex=True, sharey=True,
+                                figsize=(6, 2.8))
+        axs[0].imshow(original_image, cmap='gray')
+        axs[0].set_title('Magnitude Image')
+
+        self.draw_roi_rectangles(roi_corners, axs[0])
+        self.plot_snr_map(snr_map, fig, axs[1])
+        for ax in axs:
+            ax.axis('off')
+
+        return fig

--- a/hazenlib/tasks/snr_map.py
+++ b/hazenlib/tasks/snr_map.py
@@ -46,6 +46,7 @@ class SNRMap(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.single_dcm = self.dcm_list[0]
         # Initialise variables
         self.kernel_len = 9
         self.roi_size = 20

--- a/hazenlib/tasks/snr_map.py
+++ b/hazenlib/tasks/snr_map.py
@@ -68,8 +68,8 @@ class SNRMap(HazenTask):
         results : dict
         """
         results = self.init_result_dict()
-
-        key = self.key(self.single_dcm)
+        img_desc = self.img_desc(self.single_dcm)
+        results['file'] = img_desc
 
         #  Create original, smoothed and noise images
         #  ==========================================
@@ -105,7 +105,7 @@ class SNRMap(HazenTask):
         #  =================================
         snr_map = self.calc_snr_map(original, noise)
 
-        results[key] = round(snr, 2)
+        results['measurement'] = {"snr by smoothing": round(snr, 2)}
 
         if self.report:
             #  Plot images
@@ -116,8 +116,8 @@ class SNRMap(HazenTask):
 
             #  Save images
             #  ===========
-            detailed_image_path = os.path.join(self.report_path, f'{key}_snr_map_detailed.png')
-            summary_image_path = os.path.join(self.report_path, f'{key}_snr_map.png')
+            detailed_image_path = os.path.join(self.report_path, f'{img_desc}_snr_map_detailed.png')
+            summary_image_path = os.path.join(self.report_path, f'{img_desc}_snr_map.png')
 
             fig_detailed.savefig(detailed_image_path, dpi=300)
             fig_summary.savefig(summary_image_path, dpi=300)
@@ -125,7 +125,7 @@ class SNRMap(HazenTask):
             self.report_files.append(summary_image_path)
             self.report_files.append(detailed_image_path)
 
-            results['report_images'] = self.report_files
+            results['report_image'] = self.report_files
 
         return results
 

--- a/hazenlib/tasks/snr_map.py
+++ b/hazenlib/tasks/snr_map.py
@@ -216,7 +216,7 @@ class SNRMap(HazenTask):
             # but using ddof=1 for consistency with IDL code.
 
         roi_snr = np.array(roi_signal) / np.array(roi_noise)
-        snr = roi_snr.mean()
+        snr = round(roi_snr.mean(), 2)
 
         logger.debug('ROIs signal=%r, noise=%r, snr=%r',
                      roi_signal, roi_noise, roi_snr)

--- a/hazenlib/tasks/snr_map.py
+++ b/hazenlib/tasks/snr_map.py
@@ -67,7 +67,7 @@ class SNRMap(HazenTask):
         -------
         results : dict
         """
-        results = {}
+        results = self.init_result_dict()
 
         key = self.key(self.single_dcm)
 

--- a/hazenlib/tasks/spatial_resolution.py
+++ b/hazenlib/tasks/spatial_resolution.py
@@ -362,7 +362,7 @@ class SpatialResolution(HazenTask):
             axes[10].set_title('normalised MTF')
             axes[10].plot(freqs[mask], norm_mtf[mask])
             axes[10].set_xlabel('lp/mm')
-            logger.info(f'Writing report image: {self.report_path}_{pe}_{edge}.png')
+            logger.debug(f'Writing report image: {self.report_path}_{pe}_{edge}.png')
             img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(dicom)}_{pe}_{edge}.png'))
             fig.savefig(img_path)
             self.report_files.append(img_path)

--- a/hazenlib/tasks/spatial_resolution.py
+++ b/hazenlib/tasks/spatial_resolution.py
@@ -375,7 +375,7 @@ class SpatialResolution(HazenTask):
 
         return res
 
-    def calculate_mtf(self, dicom):
+    def calculate_mtf(self, dicom) -> tuple:
         pe = dicom.InPlanePhaseEncodingDirection
         pe_result, fe_result = None, None
 

--- a/hazenlib/tasks/spatial_resolution.py
+++ b/hazenlib/tasks/spatial_resolution.py
@@ -38,7 +38,7 @@ class SpatialResolution(HazenTask):
 
         # only return reports if requested
         if self.report:
-            results['reports'] = {'images': self.report_files}
+            results['report_images'] = self.report_files
 
         return results
 

--- a/hazenlib/tasks/spatial_resolution.py
+++ b/hazenlib/tasks/spatial_resolution.py
@@ -29,7 +29,7 @@ class SpatialResolution(HazenTask):
         super().__init__(**kwargs)
 
     def run(self) -> dict:
-        results = {}
+        results = self.init_result_dict()
         try:
             results[self.key(self.single_dcm)] = self.calculate_mtf(self.single_dcm)
         except Exception as e:

--- a/hazenlib/tasks/spatial_resolution.py
+++ b/hazenlib/tasks/spatial_resolution.py
@@ -27,6 +27,7 @@ class SpatialResolution(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.single_dcm = self.dcm_list[0]
 
     def run(self) -> dict:
         results = self.init_result_dict()

--- a/hazenlib/tasks/spatial_resolution.py
+++ b/hazenlib/tasks/spatial_resolution.py
@@ -30,13 +30,11 @@ class SpatialResolution(HazenTask):
 
     def run(self) -> dict:
         results = {}
-        for dcm in self.data:
-            try:
-                results[self.key(dcm)] = self.calculate_mtf(dcm)
-            except Exception as e:
-                print(f"Could not calculate the spatial resolution for {self.key(dcm)} because of : {e}")
-                traceback.print_exc(file=sys.stdout)
-                continue
+        try:
+            results[self.key(self.single_dcm)] = self.calculate_mtf(self.single_dcm)
+        except Exception as e:
+            print(f"Could not calculate the spatial resolution for {self.key(self.single_dcm)} because of : {e}")
+            traceback.print_exc(file=sys.stdout)
 
         # only return reports if requested
         if self.report:

--- a/hazenlib/tasks/spatial_resolution.py
+++ b/hazenlib/tasks/spatial_resolution.py
@@ -380,4 +380,5 @@ class SpatialResolution(HazenTask):
             pe_result = self.calculate_mtf_for_edge(dicom, 'right')
             fe_result = self.calculate_mtf_for_edge(dicom, 'top')
 
-        return {'phase_encoding_direction': pe_result, 'frequency_encoding_direction': fe_result}
+        return {'phase encoding direction mm': round(pe_result, 2),
+                'frequency encoding direction mm': round(fe_result, 2)}

--- a/hazenlib/tasks/uniformity.py
+++ b/hazenlib/tasks/uniformity.py
@@ -35,16 +35,21 @@ class Uniformity(HazenTask):
 
     def run(self) -> dict:
         results = self.init_result_dict()
+        results['file'] = self.img_desc(self.single_dcm)
 
         try:
-            results[self.key(self.single_dcm)] = self.get_fractional_uniformity(self.single_dcm)
+            horizontal_uniformity, vertical_uniformity = self.get_fractional_uniformity(self.single_dcm)
+            results['measurement'] = {
+                "horizontal uniformity": round(horizontal_uniformity, 2),
+                "vertical uniformity": round(vertical_uniformity, 2),
+                }
         except Exception as e:
-            print(f"Could test not calculate the uniformity for {self.key(self.single_dcm)} because of : {e}")
+            print(f"Could test not calculate the uniformity for {self.img_desc(self.single_dcm)} because of : {e}")
             traceback.print_exc(file=sys.stdout)
 
         # only return reports if requested
         if self.report:
-            results['report_images'] = self.report_files
+            results['report_image'] = self.report_files
 
         return results
 
@@ -124,8 +129,8 @@ class Uniformity(HazenTask):
         vertical_count = len(vertical_count[0])
 
         # Calculate fractional uniformity
-        fractional_uniformity_horizontal = round(horizontal_count / 160, 2)
-        fractional_uniformity_vertical = round(vertical_count / 160, 2)
+        fractional_uniformity_horizontal = horizontal_count / 160
+        fractional_uniformity_vertical = vertical_count / 160
 
         if self.report:
             import matplotlib.pyplot as plt
@@ -140,9 +145,9 @@ class Uniformity(HazenTask):
             ax.add_collection(pc)
             ax.scatter(x, y, 5)
 
-            img_path = os.path.realpath(os.path.join(self.report_path, f'{self.key(dcm)}.png'))
+            img_path = os.path.realpath(os.path.join(self.report_path,
+                                            f'{self.img_desc(dcm)}.png'))
             fig.savefig(img_path)
             self.report_files.append(img_path)
 
-        return {'horizontal %': fractional_uniformity_horizontal,
-                'vertical %': fractional_uniformity_vertical}
+        return fractional_uniformity_horizontal, fractional_uniformity_vertical

--- a/hazenlib/tasks/uniformity.py
+++ b/hazenlib/tasks/uniformity.py
@@ -44,7 +44,7 @@ class Uniformity(HazenTask):
 
         # only return reports if requested
         if self.report:
-            results['reports'] = {'images': self.report_files}
+            results['report_images'] = self.report_files
 
         return results
 

--- a/hazenlib/tasks/uniformity.py
+++ b/hazenlib/tasks/uniformity.py
@@ -34,7 +34,7 @@ class Uniformity(HazenTask):
         super().__init__(**kwargs)
 
     def run(self) -> dict:
-        results = {}
+        results = self.init_result_dict()
 
         try:
             results[self.key(self.single_dcm)] = self.get_fractional_uniformity(self.single_dcm)

--- a/hazenlib/tasks/uniformity.py
+++ b/hazenlib/tasks/uniformity.py
@@ -40,8 +40,8 @@ class Uniformity(HazenTask):
         try:
             horizontal_uniformity, vertical_uniformity = self.get_fractional_uniformity(self.single_dcm)
             results['measurement'] = {
-                "horizontal uniformity": round(horizontal_uniformity, 2),
-                "vertical uniformity": round(vertical_uniformity, 2),
+                "horizontal %": round(horizontal_uniformity, 2),
+                "vertical %": round(vertical_uniformity, 2),
                 }
         except Exception as e:
             print(f"Could test not calculate the uniformity for {self.img_desc(self.single_dcm)} because of : {e}")

--- a/hazenlib/tasks/uniformity.py
+++ b/hazenlib/tasks/uniformity.py
@@ -124,8 +124,8 @@ class Uniformity(HazenTask):
         vertical_count = len(vertical_count[0])
 
         # Calculate fractional uniformity
-        fractional_uniformity_horizontal = horizontal_count / 160
-        fractional_uniformity_vertical = vertical_count / 160
+        fractional_uniformity_horizontal = round(horizontal_count / 160, 2)
+        fractional_uniformity_vertical = round(vertical_count / 160, 2)
 
         if self.report:
             import matplotlib.pyplot as plt
@@ -144,5 +144,5 @@ class Uniformity(HazenTask):
             fig.savefig(img_path)
             self.report_files.append(img_path)
 
-        return {'horizontal': fractional_uniformity_horizontal,
-                'vertical': fractional_uniformity_vertical}
+        return {'horizontal %': fractional_uniformity_horizontal,
+                'vertical %': fractional_uniformity_vertical}

--- a/hazenlib/tasks/uniformity.py
+++ b/hazenlib/tasks/uniformity.py
@@ -32,6 +32,7 @@ class Uniformity(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.single_dcm = self.dcm_list[0]
 
     def run(self) -> dict:
         results = self.init_result_dict()

--- a/hazenlib/tasks/uniformity.py
+++ b/hazenlib/tasks/uniformity.py
@@ -36,15 +36,11 @@ class Uniformity(HazenTask):
     def run(self) -> dict:
         results = {}
 
-        for dcm in self.data:
-            try:
-                result = self.get_fractional_uniformity(dcm)
-            except Exception as e:
-                print(f"Could test not calculate the uniformity for {self.key(dcm)} because of : {e}")
-                traceback.print_exc(file=sys.stdout)
-                continue
-
-            results[self.key(dcm)] = result
+        try:
+            results[self.key(self.single_dcm)] = self.get_fractional_uniformity(self.single_dcm)
+        except Exception as e:
+            print(f"Could test not calculate the uniformity for {self.key(self.single_dcm)} because of : {e}")
+            traceback.print_exc(file=sys.stdout)
 
         # only return reports if requested
         if self.report:

--- a/tests/test_acr_geometric_accuracy.py
+++ b/tests/test_acr_geometric_accuracy.py
@@ -13,6 +13,7 @@ from tests import TEST_DATA_DIR, TEST_REPORT_DIR
 class TestACRGeometricAccuracySiemens(unittest.TestCase):
     L1 = 192.38, 188.48
     L5 = 192.38, 188.48, 190.43, 192.38
+    distortion_metrics = [0.75, 2.38, 0.92]
 
     def setUp(self):
         ACR_DATA_SIEMENS = pathlib.Path(TEST_DATA_DIR / 'acr' / 'Siemens')
@@ -25,11 +26,11 @@ class TestACRGeometricAccuracySiemens(unittest.TestCase):
             [pydicom.read_file(os.path.join(ACR_DATA_SIEMENS, f'{i}')) for i in
              os.listdir(ACR_DATA_SIEMENS)])
 
-        self.dcm_1 = self.acr_geometric_accuracy_task.ACR_obj.dcm[0]
-        self.dcm_5 = self.acr_geometric_accuracy_task.ACR_obj.dcm[4]
+        self.dcm_1 = self.acr_geometric_accuracy_task.ACR_obj.dcms[0]
+        self.dcm_5 = self.acr_geometric_accuracy_task.ACR_obj.dcms[4]
 
     def test_geometric_accuracy_slice_1(self):
-        slice1_vals = np.array(self.acr_geometric_accuracy_task.get_geometric_accuracy_slice1(self.dcm_1))
+        slice1_vals = self.acr_geometric_accuracy_task.get_geometric_accuracy_slice1(self.dcm_1)
         slice1_vals = np.round(slice1_vals, 2)
 
         print("\ntest_geo_accuracy.py::TestGeoAccuracy::test_geo_accuracy_slice1")
@@ -42,15 +43,19 @@ class TestACRGeometricAccuracySiemens(unittest.TestCase):
         slice5_vals = np.array(self.acr_geometric_accuracy_task.get_geometric_accuracy_slice5(self.dcm_5))
         slice5_vals = np.round(slice5_vals, 2)
 
-        print("\ntest_geo_accuracy.py::TestGeoAccuracy::test_geo_accuracy_slice1")
+        print("\ntest_geo_accuracy.py::TestGeoAccuracy::test_geo_accuracy_slice5")
         print("new_release:", slice5_vals)
         print("fixed value:", self.L5)
         assert (slice5_vals == self.L5).all() == True
 
+    def test_distortion_metrics(self):
+        metrics = np.array(self.acr_geometric_accuracy_task.distortion_metric(self.L1 + self.L5))
+        metrics = np.round(metrics, 2)
+        assert (metrics == self.distortion_metrics).all() == True
 
 # TODO: Add unit tests for Philips datasets.
 
-class TestACRGeometricAccuracyGE(unittest.TestCase):
+class TestACRGeometricAccuracyGE(TestACRGeometricAccuracySiemens):
     L1 = 191.44, 191.44
     L5 = 191.44, 191.44, 191.44, 189.41
     distortion_metrics = [1.1, 1.44, 0.4]
@@ -66,20 +71,6 @@ class TestACRGeometricAccuracyGE(unittest.TestCase):
             [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
              os.listdir(ACR_DATA_GE)])
 
-        self.dcm_1 = self.acr_geometric_accuracy_task.ACR_obj.dcm[0]
-        self.dcm_5 = self.acr_geometric_accuracy_task.ACR_obj.dcm[4]
+        self.dcm_1 = self.acr_geometric_accuracy_task.ACR_obj.dcms[0]
+        self.dcm_5 = self.acr_geometric_accuracy_task.ACR_obj.dcms[4]
 
-    def test_geo_accuracy_slice1(self):
-        slice1_vals = np.array(self.acr_geometric_accuracy_task.get_geometric_accuracy_slice1(self.dcm_1))
-        slice1_vals = np.round(slice1_vals, 2)
-        assert (slice1_vals == self.L1).all() == True
-
-    def test_geo_accuracy_slice5(self):
-        slice5_vals = np.array(self.acr_geometric_accuracy_task.get_geometric_accuracy_slice5(self.dcm_5))
-        slice5_vals = np.round(slice5_vals, 2)
-        assert (slice5_vals == self.L5).all() == True
-
-    def test_distortion_metrics(self):
-        metrics = np.array(self.acr_geometric_accuracy_task.distortion_metric(self.L1 + self.L5))
-        metrics = np.round(metrics, 2)
-        assert (metrics == self.distortion_metrics).all() == True

--- a/tests/test_acr_geometric_accuracy.py
+++ b/tests/test_acr_geometric_accuracy.py
@@ -15,7 +15,7 @@ class TestACRGeometricAccuracySiemens(unittest.TestCase):
     L5 = 192.38, 188.48, 190.43, 192.38
 
     def setUp(self):
-        self.acr_geometric_accuracy_task = ACRGeometricAccuracy(data_paths=[os.path.join(TEST_DATA_DIR, 'acr')],
+        self.acr_geometric_accuracy_task = ACRGeometricAccuracy(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
                                                                 report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.acr_geometric_accuracy_task.ACR_obj = ACRObject(
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens', f'{i}')) for i in
@@ -53,7 +53,7 @@ class TestACRGeometricAccuracyGE(unittest.TestCase):
     distortion_metrics = [1.1, 1.44, 0.4]
 
     def setUp(self):
-        self.acr_geometric_accuracy_task = ACRGeometricAccuracy(data_paths=[os.path.join(TEST_DATA_DIR, 'acr')],
+        self.acr_geometric_accuracy_task = ACRGeometricAccuracy(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
                                                                 report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.acr_geometric_accuracy_task.ACR_obj = ACRObject(
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'GE', f'{i}')) for i in

--- a/tests/test_acr_geometric_accuracy.py
+++ b/tests/test_acr_geometric_accuracy.py
@@ -4,22 +4,26 @@ import pathlib
 import pydicom
 import numpy as np
 
+from hazenlib.utils import get_dicom_files
 from hazenlib.tasks.acr_geometric_accuracy import ACRGeometricAccuracy
 from hazenlib.ACRObject import ACRObject
 from tests import TEST_DATA_DIR, TEST_REPORT_DIR
 
 
 class TestACRGeometricAccuracySiemens(unittest.TestCase):
-    ACR_GEOMETRIC_ACCURACY_DATA = pathlib.Path(TEST_DATA_DIR / 'acr')
     L1 = 192.38, 188.48
     L5 = 192.38, 188.48, 190.43, 192.38
 
     def setUp(self):
-        self.acr_geometric_accuracy_task = ACRGeometricAccuracy(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
-                                                                report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
+        ACR_DATA_SIEMENS = pathlib.Path(TEST_DATA_DIR / 'acr' / 'Siemens')
+        siemens_files = get_dicom_files(ACR_DATA_SIEMENS)
+
+        self.acr_geometric_accuracy_task = ACRGeometricAccuracy(
+            input_data=siemens_files,
+            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.acr_geometric_accuracy_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens', f'{i}')) for i in
-             os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens'))])
+            [pydicom.read_file(os.path.join(ACR_DATA_SIEMENS, f'{i}')) for i in
+             os.listdir(ACR_DATA_SIEMENS)])
 
         self.dcm_1 = self.acr_geometric_accuracy_task.ACR_obj.dcm[0]
         self.dcm_5 = self.acr_geometric_accuracy_task.ACR_obj.dcm[4]
@@ -47,17 +51,20 @@ class TestACRGeometricAccuracySiemens(unittest.TestCase):
 # TODO: Add unit tests for Philips datasets.
 
 class TestACRGeometricAccuracyGE(unittest.TestCase):
-    ACR_GEOMETRIC_ACCURACY_DATA = pathlib.Path(TEST_DATA_DIR / 'acr')
     L1 = 191.44, 191.44
     L5 = 191.44, 191.44, 191.44, 189.41
     distortion_metrics = [1.1, 1.44, 0.4]
 
     def setUp(self):
-        self.acr_geometric_accuracy_task = ACRGeometricAccuracy(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
-                                                                report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
+        ACR_DATA_GE = pathlib.Path(TEST_DATA_DIR / 'acr' / 'GE')
+        ge_files = get_dicom_files(ACR_DATA_GE)
+
+        self.acr_geometric_accuracy_task = ACRGeometricAccuracy(
+            input_data=ge_files,
+            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.acr_geometric_accuracy_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'GE', f'{i}')) for i in
-             os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'GE'))])
+            [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
+             os.listdir(ACR_DATA_GE)])
 
         self.dcm_1 = self.acr_geometric_accuracy_task.ACR_obj.dcm[0]
         self.dcm_5 = self.acr_geometric_accuracy_task.ACR_obj.dcm[4]

--- a/tests/test_acr_ghosting.py
+++ b/tests/test_acr_ghosting.py
@@ -24,7 +24,7 @@ class TestACRGhostingSiemens(unittest.TestCase):
             [pydicom.read_file(os.path.join(ACR_DATA_SIEMENS, f'{i}')) for i in
              os.listdir(ACR_DATA_SIEMENS)])
 
-        self.dcm = self.acr_ghosting_task.ACR_obj.dcm[6]
+        self.dcm = self.acr_ghosting_task.ACR_obj.dcms[6]
 
     def test_ghosting(self):
         ghosting_val = round(self.acr_ghosting_task.get_signal_ghosting(self.dcm), 3)
@@ -51,7 +51,7 @@ class TestACRGhostingGE(unittest.TestCase):
             [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
              os.listdir(ACR_DATA_GE)])
 
-        self.dcm = self.acr_ghosting_task.ACR_obj.dcm[6]
+        self.dcm = self.acr_ghosting_task.ACR_obj.dcms[6]
 
     def test_ghosting(self):
         assert round(self.acr_ghosting_task.get_signal_ghosting(self.dcm), 3) == self.psg

--- a/tests/test_acr_ghosting.py
+++ b/tests/test_acr_ghosting.py
@@ -3,23 +3,26 @@ import unittest
 import pathlib
 import pydicom
 
+from hazenlib.utils import get_dicom_files
 from hazenlib.tasks.acr_ghosting import ACRGhosting
 from hazenlib.ACRObject import ACRObject
 from tests import TEST_DATA_DIR, TEST_REPORT_DIR
 
 
 class TestACRGhostingSiemens(unittest.TestCase):
-    ACR_GHOSTING_DATA = pathlib.Path(TEST_DATA_DIR / 'acr')
     centre = [129, 128]
     psg = 0.035
 
     def setUp(self):
-        self.acr_ghosting_task = ACRGhosting(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
-                                             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
+        ACR_DATA_SIEMENS = pathlib.Path(TEST_DATA_DIR / 'acr' / 'Siemens')
+        siemens_files = get_dicom_files(ACR_DATA_SIEMENS)
+        self.acr_ghosting_task = ACRGhosting(
+            input_data=siemens_files,
+            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
         self.acr_ghosting_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens', f'{i}')) for i in
-             os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens'))])
+            [pydicom.read_file(os.path.join(ACR_DATA_SIEMENS, f'{i}')) for i in
+             os.listdir(ACR_DATA_SIEMENS)])
 
         self.dcm = self.acr_ghosting_task.ACR_obj.dcm[6]
 
@@ -34,16 +37,19 @@ class TestACRGhostingSiemens(unittest.TestCase):
 
 
 class TestACRGhostingGE(unittest.TestCase):
-    ACR_GHOSTING_DATA = pathlib.Path(TEST_DATA_DIR / 'acr')
     centre = [253, 256]
     psg = 0.471
 
     def setUp(self):
-        self.acr_ghosting_task = ACRGhosting(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
-                                             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
+        ACR_DATA_GE = pathlib.Path(TEST_DATA_DIR / 'acr' / 'GE')
+        ge_files = get_dicom_files(ACR_DATA_GE)
+
+        self.acr_ghosting_task = ACRGhosting(
+            input_data=ge_files,
+            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.acr_ghosting_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'GE', f'{i}')) for i in
-             os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'GE'))])
+            [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
+             os.listdir(ACR_DATA_GE)])
 
         self.dcm = self.acr_ghosting_task.ACR_obj.dcm[6]
 

--- a/tests/test_acr_ghosting.py
+++ b/tests/test_acr_ghosting.py
@@ -14,7 +14,7 @@ class TestACRGhostingSiemens(unittest.TestCase):
     psg = 0.035
 
     def setUp(self):
-        self.acr_ghosting_task = ACRGhosting(data_paths=[os.path.join(TEST_DATA_DIR, 'acr')],
+        self.acr_ghosting_task = ACRGhosting(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
                                              report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
         self.acr_ghosting_task.ACR_obj = ACRObject(
@@ -39,7 +39,7 @@ class TestACRGhostingGE(unittest.TestCase):
     psg = 0.471
 
     def setUp(self):
-        self.acr_ghosting_task = ACRGhosting(data_paths=[os.path.join(TEST_DATA_DIR, 'acr')],
+        self.acr_ghosting_task = ACRGhosting(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
                                              report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.acr_ghosting_task.ACR_obj = ACRObject(
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'GE', f'{i}')) for i in

--- a/tests/test_acr_slice_position.py
+++ b/tests/test_acr_slice_position.py
@@ -15,7 +15,7 @@ class TestACRSlicePositionSiemens(unittest.TestCase):
     dL = -0.59, -1.56
 
     def setUp(self):
-        self.acr_slice_position_task = ACRSlicePosition(data_paths=[os.path.join(TEST_DATA_DIR, 'acr')])
+        self.acr_slice_position_task = ACRSlicePosition(input_data=[os.path.join(TEST_DATA_DIR, 'acr')])
         self.acr_slice_position_task.ACR_obj = ACRObject(
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens', f'{i}')) for i in
              os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens'))])
@@ -63,7 +63,7 @@ class TestACRSlicePositionGE(unittest.TestCase):
     dL = 0.41, 0.3
 
     def setUp(self):
-        self.acr_slice_position_task = ACRSlicePosition(data_paths=[os.path.join(TEST_DATA_DIR, 'acr')])
+        self.acr_slice_position_task = ACRSlicePosition(input_data=[os.path.join(TEST_DATA_DIR, 'acr')])
         self.acr_slice_position_task.ACR_obj = ACRObject(
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'GE', f'{i}')) for i in
              os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'GE'))])

--- a/tests/test_acr_slice_position.py
+++ b/tests/test_acr_slice_position.py
@@ -3,22 +3,25 @@ import unittest
 import pathlib
 import pydicom
 
+from hazenlib.utils import get_dicom_files
 from hazenlib.tasks.acr_slice_position import ACRSlicePosition
 from hazenlib.ACRObject import ACRObject
 from tests import TEST_DATA_DIR
 
 
 class TestACRSlicePositionSiemens(unittest.TestCase):
-    ACR_SLICE_POSITION_DATA = pathlib.Path(TEST_DATA_DIR / 'acr')
     x_pts = [(123, 129), (123, 129)]
     y_pts = [(40, 82), (44, 82)]
     dL = -0.59, -1.56
 
     def setUp(self):
-        self.acr_slice_position_task = ACRSlicePosition(input_data=[os.path.join(TEST_DATA_DIR, 'acr')])
+        ACR_DATA_SIEMENS = pathlib.Path(TEST_DATA_DIR / 'acr' / 'Siemens')
+        siemens_files = get_dicom_files(ACR_DATA_SIEMENS)
+
+        self.acr_slice_position_task = ACRSlicePosition(input_data=siemens_files)
         self.acr_slice_position_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens', f'{i}')) for i in
-             os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens'))])
+            [pydicom.read_file(os.path.join(ACR_DATA_SIEMENS, f'{i}')) for i in
+             os.listdir(ACR_DATA_SIEMENS)])
 
         self.dcm_1 = self.acr_slice_position_task.ACR_obj.dcm[0]
         self.dcm_11 = self.acr_slice_position_task.ACR_obj.dcm[-1]
@@ -57,16 +60,18 @@ class TestACRSlicePositionSiemens(unittest.TestCase):
 
 
 class TestACRSlicePositionGE(unittest.TestCase):
-    ACR_SLICE_POSITION_DATA = pathlib.Path(TEST_DATA_DIR / 'acr')
     x_pts = [(246, 257), (246, 257)]
     y_pts = [(77, 164), (89, 162)]
     dL = 0.41, 0.3
 
     def setUp(self):
-        self.acr_slice_position_task = ACRSlicePosition(input_data=[os.path.join(TEST_DATA_DIR, 'acr')])
+        ACR_DATA_GE = pathlib.Path(TEST_DATA_DIR / 'acr' / 'GE')
+        ge_files = get_dicom_files(ACR_DATA_GE)
+
+        self.acr_slice_position_task = ACRSlicePosition(input_data=ge_files)
         self.acr_slice_position_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'GE', f'{i}')) for i in
-             os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'GE'))])
+            [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
+             os.listdir(ACR_DATA_GE)])
 
         self.dcm_1 = self.acr_slice_position_task.ACR_obj.dcm[0]
         self.dcm_11 = self.acr_slice_position_task.ACR_obj.dcm[-1]

--- a/tests/test_acr_slice_position.py
+++ b/tests/test_acr_slice_position.py
@@ -23,14 +23,14 @@ class TestACRSlicePositionSiemens(unittest.TestCase):
             [pydicom.read_file(os.path.join(ACR_DATA_SIEMENS, f'{i}')) for i in
              os.listdir(ACR_DATA_SIEMENS)])
 
-        self.dcm_1 = self.acr_slice_position_task.ACR_obj.dcm[0]
-        self.dcm_11 = self.acr_slice_position_task.ACR_obj.dcm[-1]
+        self.dcm_1 = self.acr_slice_position_task.ACR_obj.dcms[0]
+        self.dcm_11 = self.acr_slice_position_task.ACR_obj.dcms[-1]
 
     def test_wedge_find(self):
         # IMAGE 1
         img = self.dcm_1.pixel_array
         res = self.dcm_1.PixelSpacing
-        mask = self.acr_slice_position_task.ACR_obj.mask_image(img)
+        mask = self.acr_slice_position_task.ACR_obj.get_mask_image(img)
         assert (self.acr_slice_position_task.find_wedges(img, mask, res)[0] ==
                 self.x_pts[0]).all() == True
 
@@ -40,7 +40,7 @@ class TestACRSlicePositionSiemens(unittest.TestCase):
         # IMAGE 11
         img = self.dcm_11.pixel_array
         res = self.dcm_11.PixelSpacing
-        mask = self.acr_slice_position_task.ACR_obj.mask_image(img)
+        mask = self.acr_slice_position_task.ACR_obj.get_mask_image(img)
         assert (self.acr_slice_position_task.find_wedges(img, mask, res)[0] ==
                 self.x_pts[1]).all() == True
 
@@ -73,14 +73,14 @@ class TestACRSlicePositionGE(unittest.TestCase):
             [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
              os.listdir(ACR_DATA_GE)])
 
-        self.dcm_1 = self.acr_slice_position_task.ACR_obj.dcm[0]
-        self.dcm_11 = self.acr_slice_position_task.ACR_obj.dcm[-1]
+        self.dcm_1 = self.acr_slice_position_task.ACR_obj.dcms[0]
+        self.dcm_11 = self.acr_slice_position_task.ACR_obj.dcms[-1]
 
     def test_wedge_find(self):
         # IMAGE 1
         img = self.dcm_1.pixel_array
         res = self.dcm_1.PixelSpacing
-        mask = self.acr_slice_position_task.ACR_obj.mask_image(img)
+        mask = self.acr_slice_position_task.ACR_obj.get_mask_image(img)
         assert (self.acr_slice_position_task.find_wedges(img, mask, res)[0] ==
                 self.x_pts[0]).all() == True
 
@@ -90,7 +90,7 @@ class TestACRSlicePositionGE(unittest.TestCase):
         # IMAGE 11
         img = self.dcm_11.pixel_array
         res = self.dcm_11.PixelSpacing
-        mask = self.acr_slice_position_task.ACR_obj.mask_image(img)
+        mask = self.acr_slice_position_task.ACR_obj.get_mask_image(img)
         assert (self.acr_slice_position_task.find_wedges(img, mask, res)[0] ==
                 self.x_pts[1]).all() == True
 

--- a/tests/test_acr_slice_thickness.py
+++ b/tests/test_acr_slice_thickness.py
@@ -3,22 +3,25 @@ import unittest
 import pathlib
 import pydicom
 
+from hazenlib.utils import get_dicom_files
 from hazenlib.tasks.acr_slice_thickness import ACRSliceThickness
 from hazenlib.ACRObject import ACRObject
 from tests import TEST_DATA_DIR
 
 
 class TestACRSliceThicknessSiemens(unittest.TestCase):
-    ACR_SLICE_POSITION_DATA = pathlib.Path(TEST_DATA_DIR / 'acr')
     x_pts = [71, 181]
     y_pts = [132, 126]
     dz = 4.91
 
     def setUp(self):
-        self.acr_slice_thickness_task = ACRSliceThickness(input_data=[os.path.join(TEST_DATA_DIR, 'acr')])
+        ACR_DATA_SIEMENS = pathlib.Path(TEST_DATA_DIR / 'acr' / 'Siemens')
+        siemens_files = get_dicom_files(ACR_DATA_SIEMENS)
+
+        self.acr_slice_thickness_task = ACRSliceThickness(input_data=siemens_files)
         self.acr_slice_thickness_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens', f'{i}')) for i in
-             os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens'))])
+            [pydicom.read_file(os.path.join(ACR_DATA_SIEMENS, f'{i}')) for i in
+             os.listdir(ACR_DATA_SIEMENS)])
 
         self.dcm = self.acr_slice_thickness_task.ACR_obj.dcm[0]
 
@@ -42,16 +45,18 @@ class TestACRSliceThicknessSiemens(unittest.TestCase):
 
 
 class TestACRSliceThicknessGE(unittest.TestCase):
-    ACR_SLICE_POSITION_DATA = pathlib.Path(TEST_DATA_DIR / 'acr')
     x_pts = [146, 356]
     y_pts = [262, 250]
     dz = 5.02
 
     def setUp(self):
-        self.acr_slice_thickness_task = ACRSliceThickness(input_data=[os.path.join(TEST_DATA_DIR, 'acr')])
+        ACR_DATA_GE = pathlib.Path(TEST_DATA_DIR / 'acr' / 'GE')
+        ge_files = get_dicom_files(ACR_DATA_GE)
+
+        self.acr_slice_thickness_task = ACRSliceThickness(input_data=ge_files)
         self.acr_slice_thickness_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'GE', f'{i}')) for i in
-             os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'GE'))])
+            [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
+             os.listdir(ACR_DATA_GE)])
 
         self.dcm = self.acr_slice_thickness_task.ACR_obj.dcm[0]
 

--- a/tests/test_acr_slice_thickness.py
+++ b/tests/test_acr_slice_thickness.py
@@ -15,7 +15,7 @@ class TestACRSliceThicknessSiemens(unittest.TestCase):
     dz = 4.91
 
     def setUp(self):
-        self.acr_slice_thickness_task = ACRSliceThickness(data_paths=[os.path.join(TEST_DATA_DIR, 'acr')])
+        self.acr_slice_thickness_task = ACRSliceThickness(input_data=[os.path.join(TEST_DATA_DIR, 'acr')])
         self.acr_slice_thickness_task.ACR_obj = ACRObject(
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens', f'{i}')) for i in
              os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens'))])
@@ -48,7 +48,7 @@ class TestACRSliceThicknessGE(unittest.TestCase):
     dz = 5.02
 
     def setUp(self):
-        self.acr_slice_thickness_task = ACRSliceThickness(data_paths=[os.path.join(TEST_DATA_DIR, 'acr')])
+        self.acr_slice_thickness_task = ACRSliceThickness(input_data=[os.path.join(TEST_DATA_DIR, 'acr')])
         self.acr_slice_thickness_task.ACR_obj = ACRObject(
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'GE', f'{i}')) for i in
              os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'GE'))])

--- a/tests/test_acr_slice_thickness.py
+++ b/tests/test_acr_slice_thickness.py
@@ -23,7 +23,7 @@ class TestACRSliceThicknessSiemens(unittest.TestCase):
             [pydicom.read_file(os.path.join(ACR_DATA_SIEMENS, f'{i}')) for i in
              os.listdir(ACR_DATA_SIEMENS)])
 
-        self.dcm = self.acr_slice_thickness_task.ACR_obj.dcm[0]
+        self.dcm = self.acr_slice_thickness_task.ACR_obj.dcms[0]
 
     def test_ramp_find(self):
         res = self.dcm.PixelSpacing
@@ -58,7 +58,7 @@ class TestACRSliceThicknessGE(unittest.TestCase):
             [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
              os.listdir(ACR_DATA_GE)])
 
-        self.dcm = self.acr_slice_thickness_task.ACR_obj.dcm[0]
+        self.dcm = self.acr_slice_thickness_task.ACR_obj.dcms[0]
 
     def test_ramp_find(self):
         res = self.dcm.PixelSpacing

--- a/tests/test_acr_snr.py
+++ b/tests/test_acr_snr.py
@@ -21,25 +21,29 @@ class TestACRSNRSiemens(unittest.TestCase):
         self.acr_snr_task = ACRSNR(
             input_data=siemens_files,
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
-        self.acr_snr_task.ACR_obj = [ACRObject(
-            [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens', f'{i}')) for i in
-             os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens'))])]
-        self.acr_snr_task.ACR_obj.append(
-            ACRObject([pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens2', f'{i}')) for i in
-                       os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens2'))]))
+        self.acr_snr_task.ACR_obj = ACRObject(
+            [pydicom.read_file(
+                os.path.join(TEST_DATA_DIR, 'acr', 'Siemens', f'{i}')) for i in
+                os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens'))
+            ])
+        self.snr_dcm = self.acr_snr_task.ACR_obj.dcms[6]
+        self.snr_dcm2 = ACRObject(
+            [pydicom.read_file(
+                os.path.join(TEST_DATA_DIR, 'acr', 'Siemens2', f'{i}')) for i in
+                os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens2'))
+            ]).dcms[6]
 
-        self.dcm = [i.dcm[6] for i in self.acr_snr_task.ACR_obj]
 
     def test_normalisation_factor(self):
-        SNR_factor = self.acr_snr_task.get_normalised_snr_factor(self.dcm[0])
+        SNR_factor = self.acr_snr_task.get_normalised_snr_factor(self.snr_dcm)
         assert SNR_factor == self.norm_factor
 
     def test_snr_by_smoothing(self):
-        snr, _ = self.acr_snr_task.snr_by_smoothing(self.dcm[0])
+        snr, _ = self.acr_snr_task.snr_by_smoothing(self.snr_dcm)
         assert round(snr, 2) == self.snr
 
     def test_snr_by_subtraction(self):
-        snr, _ = self.acr_snr_task.snr_by_subtraction(self.dcm[0], self.dcm[1])
+        snr, _ = self.acr_snr_task.snr_by_subtraction(self.snr_dcm, self.snr_dcm2)
         rounded_snr = round(snr, 2)
 
         print("\ntest_snr_by_subtraction.py::TestSnrBySubtraction::test_snr_by_subtraction")
@@ -60,11 +64,11 @@ class TestACRSNRGE(unittest.TestCase):
         self.acr_snr_task = ACRSNR(
             input_data=ge_files,
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
-        self.acr_snr_task.ACR_obj = [ACRObject(
+        self.acr_snr_task.ACR_obj = ACRObject(
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'GE', f'{i}')) for i in
-             os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'GE'))])]
+             os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'GE'))])
 
-        self.dcm = self.acr_snr_task.ACR_obj[0].dcm[6]
+        self.dcm = self.acr_snr_task.ACR_obj.dcms[6]
 
     def test_normalisation_factor(self):
         SNR_factor = self.acr_snr_task.get_normalised_snr_factor(self.dcm)

--- a/tests/test_acr_snr.py
+++ b/tests/test_acr_snr.py
@@ -15,7 +15,7 @@ class TestACRSNRSiemens(unittest.TestCase):
     sub_snr = 75.94
 
     def setUp(self):
-        self.acr_snr_task = ACRSNR(data_paths=[os.path.join(TEST_DATA_DIR, 'acr')],
+        self.acr_snr_task = ACRSNR(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
                                    report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.acr_snr_task.ACR_obj = [ACRObject(
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens', f'{i}')) for i in
@@ -51,7 +51,7 @@ class TestACRSNRGE(unittest.TestCase):
     snr = 40.19
 
     def setUp(self):
-        self.acr_snr_task = ACRSNR(data_paths=[os.path.join(TEST_DATA_DIR, 'acr')],
+        self.acr_snr_task = ACRSNR(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
                                    report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.acr_snr_task.ACR_obj = [ACRObject(
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'GE', f'{i}')) for i in

--- a/tests/test_acr_snr.py
+++ b/tests/test_acr_snr.py
@@ -3,20 +3,24 @@ import unittest
 import pathlib
 import pydicom
 
+from hazenlib.utils import get_dicom_files
 from hazenlib.tasks.acr_snr import ACRSNR
 from hazenlib.ACRObject import ACRObject
 from tests import TEST_DATA_DIR, TEST_REPORT_DIR
 
 
 class TestACRSNRSiemens(unittest.TestCase):
-    ACR_SNR_DATA = pathlib.Path(TEST_DATA_DIR / 'acr')
     norm_factor = 9.761711312090041
     snr = 344.15
     sub_snr = 75.94
 
     def setUp(self):
-        self.acr_snr_task = ACRSNR(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
-                                   report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
+        ACR_DATA_SIEMENS = pathlib.Path(TEST_DATA_DIR / 'acr' / 'Siemens')
+        siemens_files = get_dicom_files(ACR_DATA_SIEMENS)
+
+        self.acr_snr_task = ACRSNR(
+            input_data=siemens_files,
+            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.acr_snr_task.ACR_obj = [ACRObject(
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens', f'{i}')) for i in
              os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens'))])]
@@ -46,13 +50,16 @@ class TestACRSNRSiemens(unittest.TestCase):
 
 
 class TestACRSNRGE(unittest.TestCase):
-    ACR_SNR_DATA = pathlib.Path(TEST_DATA_DIR / 'acr')
     norm_factor = 57.12810400630368
     snr = 40.19
 
     def setUp(self):
-        self.acr_snr_task = ACRSNR(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
-                                   report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
+        ACR_DATA_GE = pathlib.Path(TEST_DATA_DIR / 'acr' / 'GE')
+        ge_files = get_dicom_files(ACR_DATA_GE)
+
+        self.acr_snr_task = ACRSNR(
+            input_data=ge_files,
+            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.acr_snr_task.ACR_obj = [ACRObject(
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'GE', f'{i}')) for i in
              os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'GE'))])]

--- a/tests/test_acr_spatial_resolution.py
+++ b/tests/test_acr_spatial_resolution.py
@@ -4,13 +4,13 @@ import pathlib
 import pydicom
 import numpy as np
 
+from hazenlib.utils import get_dicom_files
 from hazenlib.tasks.acr_spatial_resolution import ACRSpatialResolution
 from hazenlib.ACRObject import ACRObject
 from tests import TEST_DATA_DIR, TEST_REPORT_DIR
 
 
 class TestACRSpatialResolutionSiemens(unittest.TestCase):
-    ACR_SPATIAL_RESOLUTION_DATA = pathlib.Path(TEST_DATA_DIR / 'acr')
     centre = (128, 124)
     rotation_angle = 9
     y_ramp_pos = 118
@@ -21,8 +21,12 @@ class TestACRSpatialResolutionSiemens(unittest.TestCase):
     MTF50 = (1.18, 1.35)
 
     def setUp(self):
-        self.acr_spatial_resolution_task = ACRSpatialResolution(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
-                                                                report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
+        ACR_DATA_SIEMENS = pathlib.Path(TEST_DATA_DIR / 'acr' / 'Siemens')
+        siemens_files = get_dicom_files(ACR_DATA_SIEMENS)
+
+        self.acr_spatial_resolution_task = ACRSpatialResolution(
+            input_data=siemens_files,
+            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.acr_spatial_resolution_task.ACR_obj = ACRObject(
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'SiemensMTF', f'{i}')) for i in
              os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'SiemensMTF'))])
@@ -57,7 +61,6 @@ class TestACRSpatialResolutionSiemens(unittest.TestCase):
         assert mtf50_val == self.MTF50
 
 class TestACRSpatialResolutionGE(unittest.TestCase):
-    ACR_SPATIAL_RESOLUTION_DATA = pathlib.Path(TEST_DATA_DIR / 'acr')
     centre = (254, 255)
     rotation_angle = 0
     y_ramp_pos = 244
@@ -68,11 +71,15 @@ class TestACRSpatialResolutionGE(unittest.TestCase):
     MTF50 = (0.72, 0.71)
 
     def setUp(self):
-        self.acr_spatial_resolution_task = ACRSpatialResolution(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
-                                                                report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
+        ACR_DATA_GE = pathlib.Path(TEST_DATA_DIR / 'acr' / 'GE')
+        ge_files = get_dicom_files(ACR_DATA_GE)
+
+        self.acr_spatial_resolution_task = ACRSpatialResolution(
+            input_data=ge_files,
+            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.acr_spatial_resolution_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'GE', f'{i}')) for i in
-             os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'GE'))])
+            [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
+             os.listdir(ACR_DATA_GE)])
 
         self.dcm = self.acr_spatial_resolution_task.ACR_obj.dcm[0]
         self.crop_image = self.acr_spatial_resolution_task.crop_image(self.dcm.pixel_array, self.centre[0],

--- a/tests/test_acr_spatial_resolution.py
+++ b/tests/test_acr_spatial_resolution.py
@@ -31,9 +31,9 @@ class TestACRSpatialResolutionSiemens(unittest.TestCase):
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'SiemensMTF', f'{i}')) for i in
              os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'SiemensMTF'))])
 
-        self.dcm = self.acr_spatial_resolution_task.ACR_obj.dcm[0]
-        self.crop_image = self.acr_spatial_resolution_task.crop_image(self.dcm.pixel_array, self.centre[0],
-                                                                      self.y_ramp_pos, self.width)
+        self.dcm = self.acr_spatial_resolution_task.ACR_obj.dcms[0]
+        self.crop_image = self.acr_spatial_resolution_task.crop_image(
+            self.dcm.pixel_array, self.centre[0], self.y_ramp_pos, self.width)
 
     def test_find_y_ramp(self):
         data = self.dcm.pixel_array
@@ -48,19 +48,21 @@ class TestACRSpatialResolutionSiemens(unittest.TestCase):
                                                                         self.edge_loc)).all()
 
     def test_retrieve_slope(self):
-        assert np.round(self.acr_spatial_resolution_task.fit_normcdf_surface(self.crop_image, self.edge_type[0],
-                                                                             self.edge_type[1])[0], 3) == self.slope
+        slope = self.acr_spatial_resolution_task.fit_normcdf_surface(
+            self.crop_image, self.edge_type[0], self.edge_type[1])[0]
+        assert np.round(slope, 3) == self.slope
 
     def test_get_MTF50(self):
-        mtf50_val = self.acr_spatial_resolution_task.get_mtf50(self.dcm)
+        mtf50 = self.acr_spatial_resolution_task.get_mtf50(self.dcm)
+        rounded_mtf50 = (np.round(mtf50[0], 2), np.round(mtf50[1], 2))
 
         print("\ntest_get_MTF50.py::TestGetMTF50::test_get_MTF50")
-        print("new_release_value:", mtf50_val)
+        print("new_release_value:", rounded_mtf50)
         print("fixed_value:", self.MTF50)
 
-        assert mtf50_val == self.MTF50
+        assert rounded_mtf50 == self.MTF50
 
-class TestACRSpatialResolutionGE(unittest.TestCase):
+class TestACRSpatialResolutionGE(TestACRSpatialResolutionSiemens):
     centre = (254, 255)
     rotation_angle = 0
     y_ramp_pos = 244
@@ -81,25 +83,6 @@ class TestACRSpatialResolutionGE(unittest.TestCase):
             [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
              os.listdir(ACR_DATA_GE)])
 
-        self.dcm = self.acr_spatial_resolution_task.ACR_obj.dcm[0]
-        self.crop_image = self.acr_spatial_resolution_task.crop_image(self.dcm.pixel_array, self.centre[0],
-                                                                      self.y_ramp_pos, self.width)
-
-    def test_find_y_ramp(self):
-        data = self.dcm.pixel_array
-        res = self.dcm.PixelSpacing
-        assert self.acr_spatial_resolution_task.y_position_for_ramp(res, data, self.centre) == self.y_ramp_pos
-
-    def test_get_edge_type(self):
-        assert self.acr_spatial_resolution_task.get_edge_type(self.crop_image) == self.edge_type
-
-    def test_get_edge_loc(self):
-        assert (self.acr_spatial_resolution_task.edge_location_for_plot(self.crop_image, self.edge_type[0] ==
-                                                                        self.edge_loc)).all()
-
-    def test_retrieve_slope(self):
-        assert np.round(self.acr_spatial_resolution_task.fit_normcdf_surface(self.crop_image, self.edge_type[0],
-                                                                             self.edge_type[1])[0], 3) == self.slope
-
-    def test_get_MTF50(self):
-        assert self.acr_spatial_resolution_task.get_mtf50(self.dcm) == self.MTF50
+        self.dcm = self.acr_spatial_resolution_task.ACR_obj.dcms[0]
+        self.crop_image = self.acr_spatial_resolution_task.crop_image(
+            self.dcm.pixel_array, self.centre[0], self.y_ramp_pos, self.width)

--- a/tests/test_acr_spatial_resolution.py
+++ b/tests/test_acr_spatial_resolution.py
@@ -21,7 +21,7 @@ class TestACRSpatialResolutionSiemens(unittest.TestCase):
     MTF50 = (1.18, 1.35)
 
     def setUp(self):
-        self.acr_spatial_resolution_task = ACRSpatialResolution(data_paths=[os.path.join(TEST_DATA_DIR, 'acr')],
+        self.acr_spatial_resolution_task = ACRSpatialResolution(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
                                                                 report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.acr_spatial_resolution_task.ACR_obj = ACRObject(
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'SiemensMTF', f'{i}')) for i in
@@ -68,7 +68,7 @@ class TestACRSpatialResolutionGE(unittest.TestCase):
     MTF50 = (0.72, 0.71)
 
     def setUp(self):
-        self.acr_spatial_resolution_task = ACRSpatialResolution(data_paths=[os.path.join(TEST_DATA_DIR, 'acr')],
+        self.acr_spatial_resolution_task = ACRSpatialResolution(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
                                                                 report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.acr_spatial_resolution_task.ACR_obj = ACRObject(
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'GE', f'{i}')) for i in

--- a/tests/test_acr_uniformity.py
+++ b/tests/test_acr_uniformity.py
@@ -3,22 +3,26 @@ import unittest
 import pathlib
 import pydicom
 
+from hazenlib.utils import get_dicom_files
 from hazenlib.tasks.acr_uniformity import ACRUniformity
 from hazenlib.ACRObject import ACRObject
 from tests import TEST_DATA_DIR, TEST_REPORT_DIR
 
 
 class TestACRUniformitySiemens(unittest.TestCase):
-    ACR_UNIFORMITY_DATA = pathlib.Path(TEST_DATA_DIR / 'acr')
     piu = 67.95
 
     def setUp(self):
-        self.acr_uniformity_task = ACRUniformity(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
-                                                 report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
+        ACR_DATA_SIEMENS = pathlib.Path(TEST_DATA_DIR / 'acr' / 'Siemens')
+        siemens_files = get_dicom_files(ACR_DATA_SIEMENS)
+
+        self.acr_uniformity_task = ACRUniformity(
+            input_data=siemens_files,
+            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
         self.acr_uniformity_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens', f'{i}')) for i in
-             os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens'))])
+            [pydicom.read_file(os.path.join(ACR_DATA_SIEMENS, f'{i}')) for i in
+             os.listdir(ACR_DATA_SIEMENS)])
 
         self.dcm = self.acr_uniformity_task.ACR_obj.dcm[6]
 
@@ -36,15 +40,18 @@ class TestACRUniformitySiemens(unittest.TestCase):
 # TODO: Add unit tests for Philips datasets.
 
 class TestACRUniformityGE(unittest.TestCase):
-    ACR_UNIFORMITY_DATA = pathlib.Path(TEST_DATA_DIR / 'acr')
     piu = 85.17
 
     def setUp(self):
-        self.acr_uniformity_task = ACRUniformity(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
-                                                 report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
+        ACR_DATA_GE = pathlib.Path(TEST_DATA_DIR / 'acr' / 'GE')
+        ge_files = get_dicom_files(ACR_DATA_GE)
+
+        self.acr_uniformity_task = ACRUniformity(
+            input_data=ge_files,
+            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.acr_uniformity_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'GE', f'{i}')) for i in
-             os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'GE'))])
+            [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
+             os.listdir(ACR_DATA_GE)])
 
         self.dcm = self.acr_uniformity_task.ACR_obj.dcm[6]
 

--- a/tests/test_acr_uniformity.py
+++ b/tests/test_acr_uniformity.py
@@ -24,7 +24,7 @@ class TestACRUniformitySiemens(unittest.TestCase):
             [pydicom.read_file(os.path.join(ACR_DATA_SIEMENS, f'{i}')) for i in
              os.listdir(ACR_DATA_SIEMENS)])
 
-        self.dcm = self.acr_uniformity_task.ACR_obj.dcm[6]
+        self.dcm = self.acr_uniformity_task.ACR_obj.dcms[6]
 
     def test_uniformity(self):
         results = self.acr_uniformity_task.get_integral_uniformity(self.dcm)
@@ -53,7 +53,7 @@ class TestACRUniformityGE(unittest.TestCase):
             [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
              os.listdir(ACR_DATA_GE)])
 
-        self.dcm = self.acr_uniformity_task.ACR_obj.dcm[6]
+        self.dcm = self.acr_uniformity_task.ACR_obj.dcms[6]
 
     def test_uniformity(self):
         results = self.acr_uniformity_task.get_integral_uniformity(self.dcm)

--- a/tests/test_acr_uniformity.py
+++ b/tests/test_acr_uniformity.py
@@ -13,7 +13,7 @@ class TestACRUniformitySiemens(unittest.TestCase):
     piu = 67.95
 
     def setUp(self):
-        self.acr_uniformity_task = ACRUniformity(data_paths=[os.path.join(TEST_DATA_DIR, 'acr')],
+        self.acr_uniformity_task = ACRUniformity(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
                                                  report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
         self.acr_uniformity_task.ACR_obj = ACRObject(
@@ -40,7 +40,7 @@ class TestACRUniformityGE(unittest.TestCase):
     piu = 85.17
 
     def setUp(self):
-        self.acr_uniformity_task = ACRUniformity(data_paths=[os.path.join(TEST_DATA_DIR, 'acr')],
+        self.acr_uniformity_task = ACRUniformity(input_data=[os.path.join(TEST_DATA_DIR, 'acr')],
                                                  report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.acr_uniformity_task.ACR_obj = ACRObject(
             [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'GE', f'{i}')) for i in

--- a/tests/test_ghosting.py
+++ b/tests/test_ghosting.py
@@ -28,7 +28,7 @@ class TestGhosting(unittest.TestCase):
         range(min(ELIGIBLE_GHOST_AREA[1]), max(ELIGIBLE_GHOST_AREA[1])), dtype=np.intp)[:, np.newaxis], np.array(
         range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0])))
 
-    GHOSTING = (None, 0.11803264099090763)
+    GHOSTING = 0.11803264099090763
 
     def setUp(self):
         self.dcm = pydicom.read_file(os.path.join(TEST_DATA_DIR, 'ghosting', 'GHOSTING', 'IM_0001.dcm'))
@@ -100,7 +100,7 @@ class TestCOLPEGhosting(TestGhosting):
         range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0])))
 
     PE = "COL"
-    GHOSTING = (None, 0.015138960417776908)
+    GHOSTING = 0.015138960417776908
 
     def setUp(self):
         self.dcm = pydicom.read_file(
@@ -126,7 +126,7 @@ class TestAxialPhilipsGhosting(TestGhosting):
         range(min(ELIGIBLE_GHOST_AREA[1]), max(ELIGIBLE_GHOST_AREA[1])), dtype=np.intp)[:, np.newaxis], np.array(
         range(min(ELIGIBLE_GHOST_AREA[0]), max(ELIGIBLE_GHOST_AREA[0])))
 
-    GHOSTING = (None, 0.007246960909896829)
+    GHOSTING = 0.007246960909896829
 
     def setUp(self):
         self.dcm = pydicom.read_file(

--- a/tests/test_ghosting.py
+++ b/tests/test_ghosting.py
@@ -32,7 +32,7 @@ class TestGhosting(unittest.TestCase):
 
     def setUp(self):
         self.dcm = pydicom.read_file(os.path.join(TEST_DATA_DIR, 'ghosting', 'GHOSTING', 'IM_0001.dcm'))
-        self.ghosting = Ghosting(data_paths=get_dicom_files(os.path.join(TEST_DATA_DIR, 'ghosting', 'GHOSTING')),
+        self.ghosting = Ghosting(input_data=get_dicom_files(os.path.join(TEST_DATA_DIR, 'ghosting', 'GHOSTING')),
                                  report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
     def test_calculate_ghost_intensity(self):
@@ -106,7 +106,7 @@ class TestCOLPEGhosting(TestGhosting):
         self.dcm = pydicom.read_file(
             os.path.join(TEST_DATA_DIR, 'ghosting', 'PE_COL_PHANTOM_BOTTOM_RIGHT', 'PE_COL_PHANTOM_BOTTOM_RIGHT.IMA'))
         self.ghosting = Ghosting(
-            data_paths=get_dicom_files(os.path.join(TEST_DATA_DIR, 'ghosting', 'PE_COL_PHANTOM_BOTTOM_RIGHT')),
+            input_data=get_dicom_files(os.path.join(TEST_DATA_DIR, 'ghosting', 'PE_COL_PHANTOM_BOTTOM_RIGHT')),
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
 
@@ -131,5 +131,5 @@ class TestAxialPhilipsGhosting(TestGhosting):
     def setUp(self):
         self.dcm = pydicom.read_file(
             os.path.join(TEST_DATA_DIR, 'ghosting', 'GHOSTING', 'axial_philips_ghosting.dcm'))
-        self.ghosting = Ghosting(data_paths=get_dicom_files(os.path.join(TEST_DATA_DIR, 'ghosting', 'GHOSTING')),
+        self.ghosting = Ghosting(input_data=get_dicom_files(os.path.join(TEST_DATA_DIR, 'ghosting', 'GHOSTING')),
                                  report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))

--- a/tests/test_hazenlib.py
+++ b/tests/test_hazenlib.py
@@ -35,20 +35,34 @@ class TestCliParser(unittest.TestCase):
 
         self.assertEqual(logging.root.level, logging.INFO)
 
-    # def test_snr_measured_slice_width(self):
-    #     path = str(TEST_DATA_DIR / 'snr' / 'GE')
-    #     files = get_dicom_files(path)
-    #     snr_task = SNR(input_data=files, report=False)
-    #     result = snr_task.run(measured_slice_width=1)
+    def test_snr_measured_slice_width(self):
+        path = str(TEST_DATA_DIR / 'snr' / 'GE')
+        files = get_dicom_files(path)
+        snr_task = SNR(input_data=files, report=False)
+        result = snr_task.run(measured_slice_width=5)
 
-    #     dict1 = {'snr_subtraction_measured_SNR_SNR_SAG_MEAS1_23_1': 183.97,
-    #              'snr_subtraction_normalised_SNR_SNR_SAG_MEAS1_23_1': 7593.04,
-    #              'snr_smoothing_measured_SNR_SNR_SAG_MEAS1_23_1': 184.41,
-    #              'snr_smoothing_measured_SNR_SNR_SAG_MEAS2_24_1': 189.38,
-    #              'snr_smoothing_normalised_SNR_SNR_SAG_MEAS1_23_1': 7610.83,
-    #              'snr_smoothing_normalised_SNR_SNR_SAG_MEAS2_24_1': 7816.0}
+        dict1 = {
+            "task": "SNR",
+            "file": ["SNR_SAG_MEAS1_23_1", "SNR_SAG_MEAS2_24_1"],
+            "measurement": {
+                "snr by smoothing": {
+                    "SNR_SAG_MEAS1_23_1": {
+                        "measured": 184.41,
+                        "normalised": 1522.17
+                    },
+                    "SNR_SAG_MEAS2_24_1": {
+                        "measured": 189.38,
+                        "normalised": 1563.2
+                    }
+                },
+                "snr by subtraction": {
+                    "measured": 183.97,
+                    "normalised": 1518.61
+                }
+            }
+        }
 
-    #     self.assertDictEqual(result['SNR_SAG_MEAS1_23_1'], dict1)
+        self.assertDictEqual(result, dict1)
 
     def test_relaxometry(self):
         path = str(TEST_DATA_DIR / 'relaxometry' / 'T1' / 'site3_ge' / 'plate4')
@@ -56,7 +70,11 @@ class TestCliParser(unittest.TestCase):
         relaxometry_task = Relaxometry(input_data=files, report=False)
         result = relaxometry_task.run(calc='T1', plate_number=4, verbose=False)
 
-        dict1 = {'Spin Echo_32_2_P4_t1': {'rms_frac_time_difference': 0.13499936644959437}}
+        dict1 = {
+            "task": "Relaxometry",
+            "file": "Spin_Echo_34_2_4_t1",
+            "measurement": {"rms_frac_time_difference": 0.135}
+        }
         self.assertEqual(dict1.keys(), result.keys())
-        self.assertAlmostEqual(dict1['Spin Echo_32_2_P4_t1']['rms_frac_time_difference'],
-                               result['Spin Echo_32_2_P4_t1']['rms_frac_time_difference'], 4)
+        self.assertAlmostEqual(dict1['measurement']['rms_frac_time_difference'],
+                               result['measurement']['rms_frac_time_difference'], 4)

--- a/tests/test_hazenlib.py
+++ b/tests/test_hazenlib.py
@@ -38,7 +38,7 @@ class TestCliParser(unittest.TestCase):
     def test_snr_measured_slice_width(self):
         path = str(TEST_DATA_DIR / 'snr' / 'GE')
         files = get_dicom_files(path)
-        snr_task = SNR(data_paths=files, report=False)
+        snr_task = SNR(input_data=files, report=False)
         result = snr_task.run(measured_slice_width=1)
 
         dict1 = {'snr_subtraction_measured_SNR_SNR_SAG_MEAS1_23_1': 183.97,
@@ -53,7 +53,7 @@ class TestCliParser(unittest.TestCase):
     def test_relaxometry(self):
         path = str(TEST_DATA_DIR / 'relaxometry' / 'T1' / 'site3_ge' / 'plate4')
         files = get_dicom_files(path)
-        relaxometry_task = Relaxometry(data_paths=files, report=False)
+        relaxometry_task = Relaxometry(input_data=files, report=False)
         result = relaxometry_task.run(calc='T1', plate_number=4, verbose=False)
 
         dict1 = {'Spin Echo_32_2_P4_t1': {'rms_frac_time_difference': 0.13499936644959437}}

--- a/tests/test_hazenlib.py
+++ b/tests/test_hazenlib.py
@@ -35,20 +35,20 @@ class TestCliParser(unittest.TestCase):
 
         self.assertEqual(logging.root.level, logging.INFO)
 
-    def test_snr_measured_slice_width(self):
-        path = str(TEST_DATA_DIR / 'snr' / 'GE')
-        files = get_dicom_files(path)
-        snr_task = SNR(input_data=files, report=False)
-        result = snr_task.run(measured_slice_width=1)
+    # def test_snr_measured_slice_width(self):
+    #     path = str(TEST_DATA_DIR / 'snr' / 'GE')
+    #     files = get_dicom_files(path)
+    #     snr_task = SNR(input_data=files, report=False)
+    #     result = snr_task.run(measured_slice_width=1)
 
-        dict1 = {'snr_subtraction_measured_SNR_SNR_SAG_MEAS1_23_1': 183.97,
-                 'snr_subtraction_normalised_SNR_SNR_SAG_MEAS1_23_1': 7593.04,
-                 'snr_smoothing_measured_SNR_SNR_SAG_MEAS1_23_1': 184.41,
-                 'snr_smoothing_measured_SNR_SNR_SAG_MEAS2_24_1': 189.38,
-                 'snr_smoothing_normalised_SNR_SNR_SAG_MEAS1_23_1': 7610.83,
-                 'snr_smoothing_normalised_SNR_SNR_SAG_MEAS2_24_1': 7816.0}
+    #     dict1 = {'snr_subtraction_measured_SNR_SNR_SAG_MEAS1_23_1': 183.97,
+    #              'snr_subtraction_normalised_SNR_SNR_SAG_MEAS1_23_1': 7593.04,
+    #              'snr_smoothing_measured_SNR_SNR_SAG_MEAS1_23_1': 184.41,
+    #              'snr_smoothing_measured_SNR_SNR_SAG_MEAS2_24_1': 189.38,
+    #              'snr_smoothing_normalised_SNR_SNR_SAG_MEAS1_23_1': 7610.83,
+    #              'snr_smoothing_normalised_SNR_SNR_SAG_MEAS2_24_1': 7816.0}
 
-        self.assertDictEqual(result['SNR_SNR_SAG_MEAS1_23_1'], dict1)
+    #     self.assertDictEqual(result['SNR_SAG_MEAS1_23_1'], dict1)
 
     def test_relaxometry(self):
         path = str(TEST_DATA_DIR / 'relaxometry' / 'T1' / 'site3_ge' / 'plate4')

--- a/tests/test_relaxometry.py
+++ b/tests/test_relaxometry.py
@@ -488,7 +488,7 @@ class TestRelaxometry(unittest.TestCase):
         dcms = get_dicom_files(self.T1_DIR)
         # dcms = [pydicom.dcmread(os.path.join(self.T1_DIR, fname)) for fname in
         #         self.T1_FILES]
-        task = Relaxometry(data_paths=dcms)
+        task = Relaxometry(input_data=dcms)
         t1_results = task.run(plate_number=5, calc="T1", verbose=True)
         # `t1_results` is a dict with one item where we don't know the key.
         # Need to extract via unpacking
@@ -501,7 +501,7 @@ class TestRelaxometry(unittest.TestCase):
         dcms = get_dicom_files(self.SITE4_T1_P4_DIR)
         # dcms = [pydicom.dcmread(os.path.join(self.SITE4_T1_P4_DIR, fname))
         #         for fname in self.SITE4_T1_P4_FILES]
-        task = Relaxometry(data_paths=dcms)
+        task = Relaxometry(input_data=dcms)
         t1_results = task.run(plate_number=4, calc="T1", verbose=True)
         # `t1_results` is a dict with one item where we don't know the key.
         # Need to extract via unpacking
@@ -515,7 +515,7 @@ class TestRelaxometry(unittest.TestCase):
         dcms = get_dicom_files(self.SITE4_T1_P5_DIR)
         # dcms = [pydicom.dcmread(os.path.join(self.SITE4_T1_P5_DIR, fname))
         #         for fname in self.SITE4_T1_P5_FILES]
-        task = Relaxometry(data_paths=dcms)
+        task = Relaxometry(input_data=dcms)
         t1_results = task.run(plate_number=5, calc="T1", verbose=True)
         results, = t1_results.values()
         np.testing.assert_allclose(results['calc_times'],
@@ -527,7 +527,7 @@ class TestRelaxometry(unittest.TestCase):
         dcms = get_dicom_files(self.SITE4_T2_P4_DIR)
         # dcms = [pydicom.dcmread(os.path.join(self.SITE4_T2_P4_DIR, fname))
         #         for fname in self.SITE4_T2_P4_FILES]
-        task = Relaxometry(data_paths=dcms)
+        task = Relaxometry(input_data=dcms)
         t2_results = task.run(plate_number=4, calc="T2", verbose=True)
         results, = t2_results.values()
         np.testing.assert_allclose(results['calc_times'],
@@ -539,7 +539,7 @@ class TestRelaxometry(unittest.TestCase):
         dcms = get_dicom_files(self.SITE4_T2_P5_DIR)
         # dcms = [pydicom.dcmread(os.path.join(self.SITE4_T2_P5_DIR, fname))
         #         for fname in self.SITE4_T2_P5_FILES]
-        task = Relaxometry(data_paths=dcms)
+        task = Relaxometry(input_data=dcms)
         t2_results = task.run(plate_number=5, calc="T2", verbose=True)
         results, = t2_results.values()
         np.testing.assert_allclose(results['calc_times'],
@@ -573,7 +573,7 @@ class TestRelaxometry(unittest.TestCase):
                 # dcms = [pydicom.dcmread(os.path.join(
                 #     getattr(self, f'SITE3_{tparam}_P{plate}_DIR'), fname))
                 #     for fname in getattr(self, f'SITE3_{tparam}_P{plate}_FILES')]
-                task = Relaxometry(data_paths=dcms)
+                task = Relaxometry(input_data=dcms)
                 t_results = task.run(plate_number=plate,
                                 calc = tparam, verbose=True)
                 results, = t_results.values()
@@ -595,7 +595,7 @@ class TestRelaxometry(unittest.TestCase):
         dcms = get_dicom_files(self.SITE5_T1_P4_DIR)
         # dcms = [pydicom.dcmread(os.path.join(self.SITE5_T1_P4_DIR, fname))
         #         for fname in self.SITE5_T1_P4_FILES]
-        task = Relaxometry(data_paths=dcms)
+        task = Relaxometry(input_data=dcms)
         t1_results = task.run(plate_number=4, calc="T1", verbose=True)
         results, = t1_results.values()
         np.testing.assert_allclose(results['calc_times'],
@@ -606,7 +606,7 @@ class TestRelaxometry(unittest.TestCase):
         dcms = get_dicom_files(self.SITE5_T1_P5_DIR)
         # dcms = [pydicom.dcmread(os.path.join(self.SITE5_T1_P5_DIR, fname))
         #         for fname in self.SITE5_T1_P5_FILES]
-        task = Relaxometry(data_paths=dcms)
+        task = Relaxometry(input_data=dcms)
         t1_results = task.run(plate_number=5, calc="T1", verbose=True)
         results, = t1_results.values()
         np.testing.assert_allclose(results['calc_times'],
@@ -617,7 +617,7 @@ class TestRelaxometry(unittest.TestCase):
         dcms = get_dicom_files(self.SITE5_T2_P4_DIR)
         # dcms = [pydicom.dcmread(os.path.join(self.SITE5_T2_P4_DIR, fname))
         #         for fname in self.SITE5_T2_P4_FILES]
-        task = Relaxometry(data_paths=dcms)
+        task = Relaxometry(input_data=dcms)
         t2_results = task.run(plate_number=4, calc="T2", verbose=True)
         results, = t2_results.values()
         np.testing.assert_allclose(results['calc_times'],
@@ -628,7 +628,7 @@ class TestRelaxometry(unittest.TestCase):
         dcms = get_dicom_files(self.SITE5_T2_P5_DIR)
         # dcms = [pydicom.dcmread(os.path.join(self.SITE5_T2_P5_DIR, fname))
         #         for fname in self.SITE5_T2_P5_FILES]
-        task = Relaxometry(data_paths=dcms)
+        task = Relaxometry(input_data=dcms)
         t2_results = task.run(plate_number=5, calc="T2", verbose=True)
         results, = t2_results.values()
         np.testing.assert_allclose(results['calc_times'],

--- a/tests/test_relaxometry.py
+++ b/tests/test_relaxometry.py
@@ -489,12 +489,10 @@ class TestRelaxometry(unittest.TestCase):
         # dcms = [pydicom.dcmread(os.path.join(self.T1_DIR, fname)) for fname in
         #         self.T1_FILES]
         task = Relaxometry(input_data=dcms)
-        t1_results = task.run(plate_number=5, calc="T1", verbose=True)
-        # `t1_results` is a dict with one item where we don't know the key.
-        # Need to extract via unpacking
-        results, = t1_results.values()
-        np.testing.assert_allclose(results['calc_times'], self.PLATE5_T1,
-                                   rtol=0.02, atol=1)
+        results = task.run(plate_number=5, calc="T1", verbose=True)
+        np.testing.assert_allclose(
+                    results['metadata']['calc_times'], self.PLATE5_T1,
+                    rtol=0.02, atol=1)
 
     def test_t1_p4_philips(self):
         """Test T1 values on plate 4 on Philips."""
@@ -502,13 +500,10 @@ class TestRelaxometry(unittest.TestCase):
         # dcms = [pydicom.dcmread(os.path.join(self.SITE4_T1_P4_DIR, fname))
         #         for fname in self.SITE4_T1_P4_FILES]
         task = Relaxometry(input_data=dcms)
-        t1_results = task.run(plate_number=4, calc="T1", verbose=True)
-        # `t1_results` is a dict with one item where we don't know the key.
-        # Need to extract via unpacking
-        results, = t1_results.values()
-        np.testing.assert_allclose(results['calc_times'],
-                                   self.SITE4_T1_P4,
-                                   rtol=0.02, atol=1)
+        results = task.run(plate_number=4, calc="T1", verbose=True)
+        np.testing.assert_allclose(
+                    results['metadata']['calc_times'], self.SITE4_T1_P4,
+                    rtol=0.02, atol=1)
 
     def test_t1_p5_philips(self):
         """Test T1 values on plate 5 on Philips."""
@@ -516,11 +511,10 @@ class TestRelaxometry(unittest.TestCase):
         # dcms = [pydicom.dcmread(os.path.join(self.SITE4_T1_P5_DIR, fname))
         #         for fname in self.SITE4_T1_P5_FILES]
         task = Relaxometry(input_data=dcms)
-        t1_results = task.run(plate_number=5, calc="T1", verbose=True)
-        results, = t1_results.values()
-        np.testing.assert_allclose(results['calc_times'],
-                                   self.SITE4_T1_P5,
-                                   rtol=0.02, atol=1)
+        results = task.run(plate_number=5, calc="T1", verbose=True)
+        np.testing.assert_allclose(
+                    results['metadata']['calc_times'], self.SITE4_T1_P5,
+                    rtol=0.02, atol=1)
 
     def test_t2_p4_philips(self):
         """Test T2 values on plate 4 on Philips."""
@@ -528,11 +522,10 @@ class TestRelaxometry(unittest.TestCase):
         # dcms = [pydicom.dcmread(os.path.join(self.SITE4_T2_P4_DIR, fname))
         #         for fname in self.SITE4_T2_P4_FILES]
         task = Relaxometry(input_data=dcms)
-        t2_results = task.run(plate_number=4, calc="T2", verbose=True)
-        results, = t2_results.values()
-        np.testing.assert_allclose(results['calc_times'],
-                                   self.SITE4_T2_P4,
-                                   rtol=0.02, atol=1)
+        results = task.run(plate_number=4, calc="T2", verbose=True)
+        np.testing.assert_allclose(
+                    results['metadata']['calc_times'], self.SITE4_T2_P4,
+                    rtol=0.02, atol=1)
 
     def test_t2_p5_philips(self):
         """Test T2 values on plate 4 on Philips."""
@@ -540,11 +533,10 @@ class TestRelaxometry(unittest.TestCase):
         # dcms = [pydicom.dcmread(os.path.join(self.SITE4_T2_P5_DIR, fname))
         #         for fname in self.SITE4_T2_P5_FILES]
         task = Relaxometry(input_data=dcms)
-        t2_results = task.run(plate_number=5, calc="T2", verbose=True)
-        results, = t2_results.values()
-        np.testing.assert_allclose(results['calc_times'],
-                                   self.SITE4_T2_P5,
-                                   rtol=0.02, atol=1)
+        results = task.run(plate_number=5, calc="T2", verbose=True)
+        np.testing.assert_allclose(
+                    results['metadata']['calc_times'], self.SITE4_T2_P5,
+                    rtol=0.02, atol=1)
 
     def test_scale_up_template(self):
         """Test fit for 256x256 GE image with 192x192 template"""
@@ -574,11 +566,10 @@ class TestRelaxometry(unittest.TestCase):
                 #     getattr(self, f'SITE3_{tparam}_P{plate}_DIR'), fname))
                 #     for fname in getattr(self, f'SITE3_{tparam}_P{plate}_FILES')]
                 task = Relaxometry(input_data=dcms)
-                t_results = task.run(plate_number=plate,
+                results = task.run(plate_number=plate,
                                 calc = tparam, verbose=True)
-                results, = t_results.values()
                 np.testing.assert_allclose(
-                    results['calc_times'],
+                    results['metadata']['calc_times'],
                     getattr(self, f'SITE3_{tparam}_P{plate}_VALS'),
                     rtol=0.02, atol=1)
 
@@ -596,44 +587,40 @@ class TestRelaxometry(unittest.TestCase):
         # dcms = [pydicom.dcmread(os.path.join(self.SITE5_T1_P4_DIR, fname))
         #         for fname in self.SITE5_T1_P4_FILES]
         task = Relaxometry(input_data=dcms)
-        t1_results = task.run(plate_number=4, calc="T1", verbose=True)
-        results, = t1_results.values()
-        np.testing.assert_allclose(results['calc_times'],
-                                   self.SITE5_T1_P4,
-                                   rtol=0.02, atol=1)
+        results = task.run(plate_number=4, calc="T1", verbose=True)
+        np.testing.assert_allclose(
+                    results['metadata']['calc_times'], self.SITE5_T1_P4,
+                    rtol=0.02, atol=1)
 
         # T1 plate 5
         dcms = get_dicom_files(self.SITE5_T1_P5_DIR)
         # dcms = [pydicom.dcmread(os.path.join(self.SITE5_T1_P5_DIR, fname))
         #         for fname in self.SITE5_T1_P5_FILES]
         task = Relaxometry(input_data=dcms)
-        t1_results = task.run(plate_number=5, calc="T1", verbose=True)
-        results, = t1_results.values()
-        np.testing.assert_allclose(results['calc_times'],
-                                   self.SITE5_T1_P5,
-                                   rtol=0.02, atol=1)
+        results = task.run(plate_number=5, calc="T1", verbose=True)
+        np.testing.assert_allclose(
+                    results['metadata']['calc_times'], self.SITE5_T1_P5,
+                    rtol=0.02, atol=1)
 
         # T2 plate 4
         dcms = get_dicom_files(self.SITE5_T2_P4_DIR)
         # dcms = [pydicom.dcmread(os.path.join(self.SITE5_T2_P4_DIR, fname))
         #         for fname in self.SITE5_T2_P4_FILES]
         task = Relaxometry(input_data=dcms)
-        t2_results = task.run(plate_number=4, calc="T2", verbose=True)
-        results, = t2_results.values()
-        np.testing.assert_allclose(results['calc_times'],
-                                   self.SITE5_T2_P4,
-                                   rtol=0.02, atol=1)
+        results = task.run(plate_number=4, calc="T2", verbose=True)
+        np.testing.assert_allclose(
+                    results['metadata']['calc_times'], self.SITE5_T2_P4,
+                    rtol=0.02, atol=1)
 
         # T2 plate 5
         dcms = get_dicom_files(self.SITE5_T2_P5_DIR)
         # dcms = [pydicom.dcmread(os.path.join(self.SITE5_T2_P5_DIR, fname))
         #         for fname in self.SITE5_T2_P5_FILES]
         task = Relaxometry(input_data=dcms)
-        t2_results = task.run(plate_number=5, calc="T2", verbose=True)
-        results, = t2_results.values()
-        np.testing.assert_allclose(results['calc_times'],
-                                   self.SITE5_T2_P5,
-                                   rtol=0.02, atol=1)
+        results = task.run(plate_number=5, calc="T2", verbose=True)
+        np.testing.assert_allclose(
+                    results['metadata']['calc_times'], self.SITE5_T2_P5,
+                    rtol=0.02, atol=1)
 
 
 if __name__ == '__main__':

--- a/tests/test_slice_position.py
+++ b/tests/test_slice_position.py
@@ -25,7 +25,7 @@ class TestSlicePosition(unittest.TestCase):
 
     def setUp(self):
         self.hazen_slice_position = SlicePosition(
-            data_paths=get_dicom_files(os.path.join(self.SLICE_POS, 'SLICEPOSITION')),
+            input_data=get_dicom_files(os.path.join(self.SLICE_POS, 'SLICEPOSITION')),
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.sorted_slices = copy.deepcopy(self.hazen_slice_position.data)
         self.sorted_slices.sort(key=lambda x: x.SliceLocation)  # sort by slice location
@@ -67,7 +67,7 @@ class CanonTestSlicePosition(TestSlicePosition):
     def setUp(self):
         # self.test_files = [pydicom.read_file(str(i), force=True) for i in (self.SLICE_POS / 'canon').iterdir()]
         # self.test_files.sort(key=lambda x: x.SliceLocation)
-        self.hazen_slice_position = SlicePosition(data_paths=get_dicom_files(os.path.join(self.SLICE_POS, 'canon')),
+        self.hazen_slice_position = SlicePosition(input_data=get_dicom_files(os.path.join(self.SLICE_POS, 'canon')),
                                                   report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         self.sorted_slices = copy.deepcopy(self.hazen_slice_position.data)
         self.sorted_slices.sort(key=lambda x: x.SliceLocation)  # sort by slice location

--- a/tests/test_slice_position.py
+++ b/tests/test_slice_position.py
@@ -27,7 +27,7 @@ class TestSlicePosition(unittest.TestCase):
         self.hazen_slice_position = SlicePosition(
             input_data=get_dicom_files(os.path.join(self.SLICE_POS, 'SLICEPOSITION')),
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
-        self.sorted_slices = copy.deepcopy(self.hazen_slice_position.data)
+        self.sorted_slices = copy.deepcopy(self.hazen_slice_position.dcm_list)
         self.sorted_slices.sort(key=lambda x: x.SliceLocation)  # sort by slice location
 
     def test_get_rods_coords(self):
@@ -45,7 +45,7 @@ class TestSlicePosition(unittest.TestCase):
 
     def test_slice_position(self):
         results = self.hazen_slice_position.run()
-        key = self.hazen_slice_position.key(self.hazen_slice_position.data[0])
+        key = self.hazen_slice_position.key(self.hazen_slice_position.dcm_list[0])
         slice_positions = results[key]['slice_positions']
 
         print("\ntest_slice_position.py::TestSlicePosition::test_slice_position")
@@ -69,5 +69,5 @@ class CanonTestSlicePosition(TestSlicePosition):
         # self.test_files.sort(key=lambda x: x.SliceLocation)
         self.hazen_slice_position = SlicePosition(input_data=get_dicom_files(os.path.join(self.SLICE_POS, 'canon')),
                                                   report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
-        self.sorted_slices = copy.deepcopy(self.hazen_slice_position.data)
+        self.sorted_slices = copy.deepcopy(self.hazen_slice_position.dcm_list)
         self.sorted_slices.sort(key=lambda x: x.SliceLocation)  # sort by slice location

--- a/tests/test_slice_position.py
+++ b/tests/test_slice_position.py
@@ -1,7 +1,7 @@
 import unittest
 import pathlib
 import os
-import pydicom
+import numpy as np
 
 from tests import TEST_DATA_DIR, TEST_REPORT_DIR
 from hazenlib.tasks.slice_position import SlicePosition
@@ -17,11 +17,11 @@ class TestSlicePosition(unittest.TestCase):
     #                          '0', '0.0523', '0.0818', '0.165', '0.000858', '0.139', '0.00411', '0.247', '0.0931',
     #                          '0.127', '0.169', '0.240', '0.135', '0.265', '0.0125', '0.222', '0.139', '0.237', '0.125',
     #                          '0.152', '0.232', '0.0944']
-    SLICE_POSITION_OUTPUT = ['0.151', '0.0964', '0.0980', '0.101', '0.224', '0.103', '0.0873', '0.0386', '0.0459',
-                             '0.0484', '0.110', '0.0952', '0.141', '0.00583', '0.164', '0.135', '0.0186', '0.0449', '0',
-                             '0.0523', '0.0818', '0.165', '0.000847', '0.139', '0.00409', '0.247', '0.0930', '0.127',
-                             '0.170', '0.240', '0.135', '0.266', '0.0125', '0.222', '0.139', '0.237', '0.125', '0.152',
-                             '0.233', '0.0945']
+    SLICE_POSITION_OUTPUT = [0.151, 0.0964, 0.098, 0.101, 0.224, 0.103, 0.0873, 0.0386, 0.0459,
+                             0.0484, 0.11, 0.0952, 0.141, 0.00583, 0.164, 0.135, 0.0186, 0.0449, 0,
+                             0.0523, 0.0818, 0.165, 0.000847, 0.139, 0.0040, 0.247, 0.093, 0.127,
+                             0.17, 0.24, 0.135, 0.266, 0.0125, 0.222, 0.139, 0.237, 0.125, 0.152,
+                             0.233, 0.0945]
 
     def setUp(self):
         self.hazen_slice_position = SlicePosition(
@@ -43,26 +43,27 @@ class TestSlicePosition(unittest.TestCase):
 
         assert (lx, ly, rx, ry) == self.ROD_COORDS
 
-    def test_slice_position(self):
-        results = self.hazen_slice_position.run()
-        key = self.hazen_slice_position.key(self.hazen_slice_position.dcm_list[0])
-        slice_positions = results[key]['slice_positions']
+    def test_slice_position_errors(self):
+        slice_positions = self.hazen_slice_position.slice_position_error(
+            self.sorted_slices[10:50]
+        )
 
         print("\ntest_slice_position.py::TestSlicePosition::test_slice_position")
         print("new_release_value:", slice_positions)
         print("fixed_value", self.SLICE_POSITION_OUTPUT)
 
-        assert slice_positions == self.SLICE_POSITION_OUTPUT
+        np.testing.assert_allclose(
+            self.SLICE_POSITION_OUTPUT, slice_positions, atol=0.005)
 
 
 # now test on canon data
 class CanonTestSlicePosition(TestSlicePosition):
     SLICE_POS = pathlib.Path(TEST_DATA_DIR / 'slicepos')
     ROD_COORDS = (123.0, 77.5, 130.88888888888889, 171.66666666666666)
-    SLICE_POSITION_OUTPUT = ['1.49', '1.35', '1.29', '1.12', '0.928', '0.885', '0.729', '0.557', '0.531', '0.635',
-                             '0.0882', '0.437', '0.215', '0.238', '0.196', '0.0415', '0.117', '0.131', '0', '0.194',
-                             '0.361', '0.0941', '0.424', '0.265', '0.446', '0.464', '0.587', '0.646', '0.607', '0.779',
-                             '1.07', '0.880', '0.940', '0.948', '1.23', '1.29', '1.58', '1.41', '1.71', '1.95']
+    SLICE_POSITION_OUTPUT = [1.49, 1.35, 1.29, 1.12, 0.928, 0.885, 0.729, 0.557, 0.531, 0.635,
+                             0.0882, 0.437, 0.215, 0.238, 0.196, 0.0415, 0.117, 0.131, 0, 0.194,
+                             0.361, 0.0941, 0.424, 0.265, 0.446, 0.464, 0.587, 0.646, 0.607, 0.779,
+                             1.07, 0.88, 0.94, 0.948, 1.23, 1.29, 1.58, 1.41, 1.71, 1.95]
 
     def setUp(self):
         # self.test_files = [pydicom.read_file(str(i), force=True) for i in (self.SLICE_POS / 'canon').iterdir()]

--- a/tests/test_slice_width.py
+++ b/tests/test_slice_width.py
@@ -76,11 +76,11 @@ class TestSliceWidth(unittest.TestCase):
         # self.file = str(self.SLICE_WIDTH_DATA / 'SLICEWIDTH' / 'ANNUALQA.MR.HEAD_GENERAL.tra.slice_width.IMA')
         # self.dcm = pydicom.read_file(self.file)
         self.slice_width = SliceWidth(
-            input_data=get_dicom_files(os.path.join(TEST_DATA_DIR, 'slicewidth', 'SLICEWIDTH'), sort=True),
+            input_data=os.path.join(self.SLICE_WIDTH_DATA, 'SLICEWIDTH', 'ANNUALQA.MR.HEAD_GENERAL.tra.slice_width.IMA'),
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
     def test_get_rods(self):
-        rods, _ = self.slice_width.get_rods(self.slice_width.data[0])
+        rods, _ = self.slice_width.get_rods(self.slice_width.single_dcm)
         # print("rods")
         # print(rods)
         for n in range(len(rods)):
@@ -98,19 +98,19 @@ class TestSliceWidth(unittest.TestCase):
         # print("rod distortion correction coefficient")
         # print(hazen_slice_width.get_rod_distortion_correction_coefficients(distances[0], self.dcm.PixelSpacing[0]))
         assert self.slice_width.get_rod_distortion_correction_coefficients(distances[0],
-                                                                           self.slice_width.data[0].PixelSpacing[
+                                                                           self.slice_width.single_dcm.PixelSpacing[
                                                                                0]) == self.DIST_CORR_COEFF
 
     def test_rod_distortions(self):
         horizontal_distortion, vertical_distortion = self.slice_width.get_rod_distortions(self.matlab_rods,
-                                                                                          self.slice_width.data[0])
+                                                                                          self.slice_width.single_dcm)
         # print("rod distortion")
         # print(horizontal_distortion, vertical_distortion)
         assert (round(horizontal_distortion, 2), round(vertical_distortion, 2)) == self.ROD_DIST
 
     def test_get_ramp_profiles(self):
-        ramp_profiles = self.slice_width.get_ramp_profiles(self.slice_width.data[0].pixel_array, self.matlab_rods,
-                                                           self.slice_width.data[0].PixelSpacing[0])
+        ramp_profiles = self.slice_width.get_ramp_profiles(self.slice_width.single_dcm.pixel_array, self.matlab_rods,
+                                                           self.slice_width.single_dcm.PixelSpacing[0])
         bottom_profiles = ramp_profiles["bottom"]
         mean_bottom_profile = np.mean(bottom_profiles, axis=0).tolist()
         # print("bottom centre ramp profile")
@@ -127,8 +127,8 @@ class TestSliceWidth(unittest.TestCase):
         # matlab top 0.0215   -2.9668  602.4568
         # matlab bottom [0.0239, -2.9349,  694.9520]
 
-        ramps = self.slice_width.get_ramp_profiles(self.slice_width.data[0].pixel_array, self.matlab_rods,
-                                                   self.slice_width.data[0].PixelSpacing[0])
+        ramps = self.slice_width.get_ramp_profiles(self.slice_width.single_dcm.pixel_array, self.matlab_rods,
+                                                   self.slice_width.single_dcm.PixelSpacing[0])
 
         top_mean_ramp = np.mean(ramps["top"], axis=0)
         top_coefficients = list(self.slice_width.baseline_correction(top_mean_ramp, sample_spacing=0.25)["f"])
@@ -162,9 +162,9 @@ class TestSliceWidth(unittest.TestCase):
 
         """
         sample_spacing = 0.25
-        slice_thickness = self.slice_width.data[0].SliceThickness
-        ramps = self.slice_width.get_ramp_profiles(self.slice_width.data[0].pixel_array, self.matlab_rods,
-                                                   self.slice_width.data[0].PixelSpacing[0])
+        slice_thickness = self.slice_width.single_dcm.SliceThickness
+        ramps = self.slice_width.get_ramp_profiles(self.slice_width.single_dcm.pixel_array, self.matlab_rods,
+                                                   self.slice_width.single_dcm.PixelSpacing[0])
         top_mean_ramp = np.mean(ramps["top"], axis=0)
         bottom_mean_ramp = np.mean(ramps["bottom"], axis=0)
         ramps_baseline_corrected = {
@@ -186,10 +186,10 @@ class TestSliceWidth(unittest.TestCase):
 
     def test_fit_trapezoid(self):
         sample_spacing = 0.25
-        slice_thickness = self.slice_width.data[0].SliceThickness
+        slice_thickness = self.slice_width.single_dcm.SliceThickness
 
-        ramps = self.slice_width.get_ramp_profiles(self.slice_width.data[0].pixel_array, self.matlab_rods,
-                                                   self.slice_width.data[0].PixelSpacing[0])
+        ramps = self.slice_width.get_ramp_profiles(self.slice_width.single_dcm.pixel_array, self.matlab_rods,
+                                                   self.slice_width.single_dcm.PixelSpacing[0])
 
         top_mean_ramp = np.mean(ramps["top"], axis=0)
         bottom_mean_ramp = np.mean(ramps["bottom"], axis=0)
@@ -235,7 +235,7 @@ class TestSliceWidth(unittest.TestCase):
 
     def test_slice_width(self):
         results = self.slice_width.run()
-        key = self.slice_width.key(self.slice_width.data[0])
+        key = self.slice_width.key(self.slice_width.single_dcm)
         slice_width_mm = results[key]['slice_width_mm']
 
         print("\ntest_slice_width.py::TestSliceWidth::test_slice_width")
@@ -322,7 +322,7 @@ class Test512Matrix(TestSliceWidth):
 
     def setUp(self):
         self.slice_width = SliceWidth(
-            input_data=get_dicom_files(os.path.join(TEST_DATA_DIR, 'slicewidth', '512_matrix'), sort=True),
+            input_data=os.path.join(self.SLICE_WIDTH_DATA, '512_matrix', '512_matrix'),
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         # self.file = str(TEST_DATA_DIR / 'slicewidth' / 'SLICEWIDTH' / '512_matrix')
         # self.dcm = pydicom.read_file(self.file)

--- a/tests/test_slice_width.py
+++ b/tests/test_slice_width.py
@@ -237,9 +237,8 @@ class TestSliceWidth(unittest.TestCase):
             assert abs(value - matlab_baseline_fit_coefficients[idx]) <= 5
 
     def test_slice_width(self):
-        results = self.slice_width.run()
-        key = self.slice_width.key(self.slice_width.single_dcm)
-        slice_width_mm = results[key]['slice width mm']
+        result = self.slice_width.run()
+        slice_width_mm = result['measurement']['slice width mm']
 
         print("\ntest_slice_width.py::TestSliceWidth::test_slice_width")
         print("new_release_value:", slice_width_mm)

--- a/tests/test_slice_width.py
+++ b/tests/test_slice_width.py
@@ -76,7 +76,7 @@ class TestSliceWidth(unittest.TestCase):
         # self.file = str(self.SLICE_WIDTH_DATA / 'SLICEWIDTH' / 'ANNUALQA.MR.HEAD_GENERAL.tra.slice_width.IMA')
         # self.dcm = pydicom.read_file(self.file)
         self.slice_width = SliceWidth(
-            data_paths=get_dicom_files(os.path.join(TEST_DATA_DIR, 'slicewidth', 'SLICEWIDTH'), sort=True),
+            input_data=get_dicom_files(os.path.join(TEST_DATA_DIR, 'slicewidth', 'SLICEWIDTH'), sort=True),
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
     def test_get_rods(self):
@@ -322,7 +322,7 @@ class Test512Matrix(TestSliceWidth):
 
     def setUp(self):
         self.slice_width = SliceWidth(
-            data_paths=get_dicom_files(os.path.join(TEST_DATA_DIR, 'slicewidth', '512_matrix'), sort=True),
+            input_data=get_dicom_files(os.path.join(TEST_DATA_DIR, 'slicewidth', '512_matrix'), sort=True),
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         # self.file = str(TEST_DATA_DIR / 'slicewidth' / 'SLICEWIDTH' / '512_matrix')
         # self.dcm = pydicom.read_file(self.file)

--- a/tests/test_slice_width.py
+++ b/tests/test_slice_width.py
@@ -76,7 +76,8 @@ class TestSliceWidth(unittest.TestCase):
         # self.file = str(self.SLICE_WIDTH_DATA / 'SLICEWIDTH' / 'ANNUALQA.MR.HEAD_GENERAL.tra.slice_width.IMA')
         # self.dcm = pydicom.read_file(self.file)
         self.slice_width = SliceWidth(
-            input_data=os.path.join(self.SLICE_WIDTH_DATA, 'SLICEWIDTH', 'ANNUALQA.MR.HEAD_GENERAL.tra.slice_width.IMA'),
+            input_data=[os.path.join(self.SLICE_WIDTH_DATA, 'SLICEWIDTH',
+                            'ANNUALQA.MR.HEAD_GENERAL.tra.slice_width.IMA')],
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
     def test_get_rods(self):
@@ -324,7 +325,7 @@ class Test512Matrix(TestSliceWidth):
 
     def setUp(self):
         self.slice_width = SliceWidth(
-            input_data=os.path.join(self.SLICE_WIDTH_DATA, '512_matrix', '512_matrix'),
+            input_data=[os.path.join(self.SLICE_WIDTH_DATA, '512_matrix', '512_matrix')],
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
         # self.file = str(TEST_DATA_DIR / 'slicewidth' / 'SLICEWIDTH' / '512_matrix')
         # self.dcm = pydicom.read_file(self.file)

--- a/tests/test_snr.py
+++ b/tests/test_snr.py
@@ -31,7 +31,7 @@ class TestSnr(unittest.TestCase):
     LOWER_SUBTRACT_SNR = IMAGE_SUBTRACT_SNR * 0.98
 
     def setUp(self):
-        self.snr = SNR(data_paths=get_dicom_files(os.path.join(TEST_DATA_DIR, 'snr', 'Siemens'), sort=True),
+        self.snr = SNR(input_data=get_dicom_files(os.path.join(TEST_DATA_DIR, 'snr', 'Siemens'), sort=True),
                        report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
     def test_get_object_centre(self):
@@ -72,7 +72,7 @@ class TestSnrPhilips(TestSnr):
     def setUp(self):
         # self.test_file = pydicom.read_file(str(self.SNR_DATA / 'Philips' / 'Philips_IM-0011-0005.dcm'), force=True)
         # self.test_file_2 = pydicom.read_file(str(self.SNR_DATA / 'Philips' / 'Philips_IM-0011-0006.dcm'), force=True)
-        self.snr = SNR(data_paths=get_dicom_files(os.path.join(TEST_DATA_DIR, 'snr', 'Philips'), sort=True),
+        self.snr = SNR(input_data=get_dicom_files(os.path.join(TEST_DATA_DIR, 'snr', 'Philips'), sort=True),
                        report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
     def test_image_snr(self):
@@ -106,7 +106,7 @@ class TestSnrGE(TestSnr):
     def setUp(self):
         # self.test_file = pydicom.read_file(str(self.SNR_DATA / 'GE' / 'IM-0003-0001.dcm'), force=True)
         # self.test_file_2 = pydicom.read_file(str(self.SNR_DATA / 'GE' / 'IM-0004-0001.dcm'), force=True)
-        self.snr = SNR(data_paths=get_dicom_files(os.path.join(TEST_DATA_DIR, 'snr', 'GE'), sort=True),
+        self.snr = SNR(input_data=get_dicom_files(os.path.join(TEST_DATA_DIR, 'snr', 'GE'), sort=True),
                        report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
     def test_image_snr(self):
@@ -142,7 +142,7 @@ class TestSnrThreshold(TestSnr):
     def setUp(self):
         # self.test_file = pydicom.read_file(str(self.SNR_DATA / 'VIDA' / 'HC_SNR_SAG_1.dcm'), force=True)
         # self.test_file_2 = pydicom.read_file(str(self.SNR_DATA / 'VIDA' / 'HC_SNR_SAG_2.dcm'), force=True)
-        self.snr = SNR(data_paths=get_dicom_files(os.path.join(TEST_DATA_DIR, 'snr_threshold', 'VIDA'), sort=True),
+        self.snr = SNR(input_data=get_dicom_files(os.path.join(TEST_DATA_DIR, 'snr_threshold', 'VIDA'), sort=True),
                        report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
     def test_get_object_centre(self):

--- a/tests/test_snr.py
+++ b/tests/test_snr.py
@@ -35,17 +35,17 @@ class TestSnr(unittest.TestCase):
                        report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
     def test_get_object_centre(self):
-        assert self.snr.get_object_centre(self.snr.data[0]) == self.OBJECT_CENTRE
+        assert self.snr.get_object_centre(self.snr.dcm_list[0]) == self.OBJECT_CENTRE
 
     def test_image_snr(self):
         val = self.snr.run()
-        self.assertTrue(self.LOWER_SMOOTHED_SNR <= val[self.snr.key(self.snr.data[0])][
-            f"snr_smoothing_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SMOOTHED_SNR)
-        self.assertTrue(self.LOWER_SUBTRACT_SNR <= val[self.snr.key(self.snr.data[0])][
-            f"snr_subtraction_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SUBTRACT_SNR)
+        self.assertTrue(self.LOWER_SMOOTHED_SNR <= val[self.snr.key(self.snr.dcm_list[0])][
+            f"snr_smoothing_normalised_{self.snr.key(self.snr.dcm_list[0])}"] <= self.UPPER_SMOOTHED_SNR)
+        self.assertTrue(self.LOWER_SUBTRACT_SNR <= val[self.snr.key(self.snr.dcm_list[0])][
+            f"snr_subtraction_normalised_{self.snr.key(self.snr.dcm_list[0])}"] <= self.UPPER_SUBTRACT_SNR)
 
     def test_SNR_factor(self):
-        SNR_factor = self.snr.get_normalised_snr_factor(self.snr.data[0])
+        SNR_factor = self.snr.get_normalised_snr_factor(self.snr.dcm_list[0])
         assert (SNR_factor) == self.SNR_NORM_FACTOR
 
 
@@ -77,10 +77,10 @@ class TestSnrPhilips(TestSnr):
 
     def test_image_snr(self):
         val = self.snr.run()
-        self.assertTrue(self.LOWER_SMOOTHED_SNR <= val[self.snr.key(self.snr.data[0])][
-            f"snr_smoothing_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SMOOTHED_SNR)
-        self.assertTrue(self.LOWER_SUBTRACT_SNR <= val[self.snr.key(self.snr.data[0])][
-            f"snr_subtraction_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SUBTRACT_SNR)
+        self.assertTrue(self.LOWER_SMOOTHED_SNR <= val[self.snr.key(self.snr.dcm_list[0])][
+            f"snr_smoothing_normalised_{self.snr.key(self.snr.dcm_list[0])}"] <= self.UPPER_SMOOTHED_SNR)
+        self.assertTrue(self.LOWER_SUBTRACT_SNR <= val[self.snr.key(self.snr.dcm_list[0])][
+            f"snr_subtraction_normalised_{self.snr.key(self.snr.dcm_list[0])}"] <= self.UPPER_SUBTRACT_SNR)
 
 
 class TestSnrGE(TestSnr):
@@ -113,11 +113,11 @@ class TestSnrGE(TestSnr):
         # val = self.snr.run(data=[self.test_file, self.test_file_2])
         val = self.snr.run()
         self.assertTrue(
-            self.LOWER_SMOOTHED_SNR <= val[self.snr.key(self.snr.data[0])][
-                f"snr_smoothing_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SMOOTHED_SNR)
+            self.LOWER_SMOOTHED_SNR <= val[self.snr.key(self.snr.dcm_list[0])][
+                f"snr_smoothing_normalised_{self.snr.key(self.snr.dcm_list[0])}"] <= self.UPPER_SMOOTHED_SNR)
         self.assertTrue(
-            self.LOWER_SUBTRACT_SNR <= val[self.snr.key(self.snr.data[0])][
-                f"snr_subtraction_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SUBTRACT_SNR)
+            self.LOWER_SUBTRACT_SNR <= val[self.snr.key(self.snr.dcm_list[0])][
+                f"snr_subtraction_normalised_{self.snr.key(self.snr.dcm_list[0])}"] <= self.UPPER_SUBTRACT_SNR)
 
 
 class TestSnrThreshold(TestSnr):
@@ -146,14 +146,14 @@ class TestSnrThreshold(TestSnr):
                        report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
     def test_get_object_centre(self):
-        assert self.snr.get_object_centre(self.snr.data[0]) == self.OBJECT_CENTRE
+        assert self.snr.get_object_centre(self.snr.dcm_list[0]) == self.OBJECT_CENTRE
 
     def test_image_snr(self):
         val = self.snr.run()
         print("\ntest_snr.py::TestSnrThreshold::test_image_snr")
         print("set values:", val)
         print("new_release_values", self.snr.run())
-        self.assertTrue(self.LOWER_SMOOTHED_SNR <= val[self.snr.key(self.snr.data[0])][
-            f"snr_smoothing_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SMOOTHED_SNR)
-        self.assertTrue(self.LOWER_SUBTRACT_SNR <= val[self.snr.key(self.snr.data[0])][
-            f"snr_subtraction_normalised_{self.snr.key(self.snr.data[0])}"] <= self.UPPER_SUBTRACT_SNR)
+        self.assertTrue(self.LOWER_SMOOTHED_SNR <= val[self.snr.key(self.snr.dcm_list[0])][
+            f"snr_smoothing_normalised_{self.snr.key(self.snr.dcm_list[0])}"] <= self.UPPER_SMOOTHED_SNR)
+        self.assertTrue(self.LOWER_SUBTRACT_SNR <= val[self.snr.key(self.snr.dcm_list[0])][
+            f"snr_subtraction_normalised_{self.snr.key(self.snr.dcm_list[0])}"] <= self.UPPER_SUBTRACT_SNR)

--- a/tests/test_snr.py
+++ b/tests/test_snr.py
@@ -35,14 +35,20 @@ class TestSnr(unittest.TestCase):
                        report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
     def test_get_object_centre(self):
-        assert self.snr.get_object_centre(self.snr.dcm_list[0]) == self.OBJECT_CENTRE
+        object_centre = self.snr.get_object_centre(self.snr.dcm_list[0])
+        assert object_centre == self.OBJECT_CENTRE
 
     def test_image_snr(self):
         val = self.snr.run()
-        self.assertTrue(self.LOWER_SMOOTHED_SNR <= val[self.snr.key(self.snr.dcm_list[0])][
-            f"snr_smoothing_normalised_{self.snr.key(self.snr.dcm_list[0])}"] <= self.UPPER_SMOOTHED_SNR)
-        self.assertTrue(self.LOWER_SUBTRACT_SNR <= val[self.snr.key(self.snr.dcm_list[0])][
-            f"snr_subtraction_normalised_{self.snr.key(self.snr.dcm_list[0])}"] <= self.UPPER_SUBTRACT_SNR)
+        img_desc = self.snr.img_desc(self.snr.dcm_list[0])
+        smoothing_snr = val['measurement']['snr by smoothing'][img_desc]['normalised']
+        self.assertTrue(
+            self.LOWER_SMOOTHED_SNR <= smoothing_snr <= self.UPPER_SMOOTHED_SNR
+            )
+        subtract_snr = val['measurement']['snr by subtraction']['normalised']
+        self.assertTrue(
+            self.LOWER_SUBTRACT_SNR <= subtract_snr <= self.UPPER_SUBTRACT_SNR
+            )
 
     def test_SNR_factor(self):
         SNR_factor = self.snr.get_normalised_snr_factor(self.snr.dcm_list[0])
@@ -75,13 +81,6 @@ class TestSnrPhilips(TestSnr):
         self.snr = SNR(input_data=get_dicom_files(os.path.join(TEST_DATA_DIR, 'snr', 'Philips'), sort=True),
                        report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
-    def test_image_snr(self):
-        val = self.snr.run()
-        self.assertTrue(self.LOWER_SMOOTHED_SNR <= val[self.snr.key(self.snr.dcm_list[0])][
-            f"snr_smoothing_normalised_{self.snr.key(self.snr.dcm_list[0])}"] <= self.UPPER_SMOOTHED_SNR)
-        self.assertTrue(self.LOWER_SUBTRACT_SNR <= val[self.snr.key(self.snr.dcm_list[0])][
-            f"snr_subtraction_normalised_{self.snr.key(self.snr.dcm_list[0])}"] <= self.UPPER_SUBTRACT_SNR)
-
 
 class TestSnrGE(TestSnr):
     # GE ACCESSNET69-45B
@@ -109,16 +108,6 @@ class TestSnrGE(TestSnr):
         self.snr = SNR(input_data=get_dicom_files(os.path.join(TEST_DATA_DIR, 'snr', 'GE'), sort=True),
                        report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
-    def test_image_snr(self):
-        # val = self.snr.run(data=[self.test_file, self.test_file_2])
-        val = self.snr.run()
-        self.assertTrue(
-            self.LOWER_SMOOTHED_SNR <= val[self.snr.key(self.snr.dcm_list[0])][
-                f"snr_smoothing_normalised_{self.snr.key(self.snr.dcm_list[0])}"] <= self.UPPER_SMOOTHED_SNR)
-        self.assertTrue(
-            self.LOWER_SUBTRACT_SNR <= val[self.snr.key(self.snr.dcm_list[0])][
-                f"snr_subtraction_normalised_{self.snr.key(self.snr.dcm_list[0])}"] <= self.UPPER_SUBTRACT_SNR)
-
 
 class TestSnrThreshold(TestSnr):
     # SIEMENS VIDA
@@ -144,16 +133,3 @@ class TestSnrThreshold(TestSnr):
         # self.test_file_2 = pydicom.read_file(str(self.SNR_DATA / 'VIDA' / 'HC_SNR_SAG_2.dcm'), force=True)
         self.snr = SNR(input_data=get_dicom_files(os.path.join(TEST_DATA_DIR, 'snr_threshold', 'VIDA'), sort=True),
                        report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
-
-    def test_get_object_centre(self):
-        assert self.snr.get_object_centre(self.snr.dcm_list[0]) == self.OBJECT_CENTRE
-
-    def test_image_snr(self):
-        val = self.snr.run()
-        print("\ntest_snr.py::TestSnrThreshold::test_image_snr")
-        print("set values:", val)
-        print("new_release_values", self.snr.run())
-        self.assertTrue(self.LOWER_SMOOTHED_SNR <= val[self.snr.key(self.snr.dcm_list[0])][
-            f"snr_smoothing_normalised_{self.snr.key(self.snr.dcm_list[0])}"] <= self.UPPER_SMOOTHED_SNR)
-        self.assertTrue(self.LOWER_SUBTRACT_SNR <= val[self.snr.key(self.snr.dcm_list[0])][
-            f"snr_subtraction_normalised_{self.snr.key(self.snr.dcm_list[0])}"] <= self.UPPER_SUBTRACT_SNR)

--- a/tests/test_snr_map.py
+++ b/tests/test_snr_map.py
@@ -8,7 +8,7 @@ from tests import TEST_DATA_DIR, TEST_REPORT_DIR
 
 
 class TestSnrMap(unittest.TestCase):
-    siemens_1 = os.path.join(TEST_DATA_DIR, 'snr', 'Siemens', 'tra_250_2meas_1.IMA')
+    siemens_1 = [os.path.join(TEST_DATA_DIR, 'snr', 'Siemens', 'tra_250_2meas_1.IMA')]
 
     ROI_CORNERS_TEST = [np.array([114, 121]), np.array([74, 81]), np.array([154, 81]),
                         np.array([74, 161]), np.array([154, 161])]

--- a/tests/test_snr_map.py
+++ b/tests/test_snr_map.py
@@ -34,7 +34,7 @@ class TestSnrMap(unittest.TestCase):
     def test_snr_value(self):
         np.testing.assert_almost_equal(
             192.88188017908504,
-            self.results['seFoV250_2meas_slice5mm_tra_repeat_PSN_noDC_2_1'],
+            self.results['measurement']['snr by smoothing'],
             2)
 
     def test_smooth(self):

--- a/tests/test_snr_map.py
+++ b/tests/test_snr_map.py
@@ -32,8 +32,10 @@ class TestSnrMap(unittest.TestCase):
 
 
     def test_snr_value(self):
-        np.testing.assert_almost_equal(192.88188017908504,
-                                       self.results['seFoV250_2meas_slice5mm_tra_repeat_PSN_noDC_2_1'])
+        np.testing.assert_almost_equal(
+            192.88188017908504,
+            self.results['seFoV250_2meas_slice5mm_tra_repeat_PSN_noDC_2_1'],
+            2)
 
     def test_smooth(self):
         np.testing.assert_almost_equal(

--- a/tests/test_snr_map.py
+++ b/tests/test_snr_map.py
@@ -1,6 +1,4 @@
-import pathlib
 import unittest
-import pydicom
 import numpy as np
 import os.path
 import matplotlib
@@ -18,38 +16,46 @@ class TestSnrMap(unittest.TestCase):
 
     def __init__(self, methodName: str = ...):
         super().__init__(methodName)
-        self.images = None
 
     def setUp(self):
-        dcms = [self.siemens_1]  # Test on single SNR image
-        self.snr_map = SNRMap(input_data=dcms, report=True)
-        self.results = self.snr_map.run()
+        self.snr_map_task = SNRMap(input_data=self.siemens_1, report=True)
+        self.results = self.snr_map_task.run()
+        self.original, self.smoothed, self.noise = self.snr_map_task.smooth(
+            dcm=self.snr_map_task.single_dcm,
+            kernel=self.snr_map_task.kernel_len)
+        self.image_centre, self.roi_corners = self.snr_map_task.get_rois(self.smoothed)
+        self.snr = self.snr_map_task.calc_snr(self.original, self.noise, self.roi_corners)
+        self.snr_map = self.snr_map_task.calc_snr_map(self.original, self.noise)
+        self.detailed_fig = self.snr_map_task.plot_detailed(self.original, self.smoothed, self.noise,
+                    self.snr, self.snr_map, self.image_centre, self.roi_corners)
+        self.summary_fig = self.snr_map_task.plot_summary(self.snr_map, self.original, self.roi_corners)
+
 
     def test_snr_value(self):
         np.testing.assert_almost_equal(192.88188017908504,
-                                       self.results['SNRMap_seFoV250_2meas_slice5mm_tra_repeat_PSN_noDC_2_1'])
+                                       self.results['seFoV250_2meas_slice5mm_tra_repeat_PSN_noDC_2_1'])
 
     def test_smooth(self):
         np.testing.assert_almost_equal(
-            self.snr_map.original_image.cumsum().sum(), 1484467722691)
+            self.original.cumsum().sum(), 1484467722691)
         np.testing.assert_almost_equal(
-            self.snr_map.smooth_image.cumsum().sum(), 1484468146211.5635)
+            self.smoothed.cumsum().sum(), 1484468146211.5635)
         np.testing.assert_almost_equal(
-            abs(self.snr_map.noise_image).sum(), 2147755.9753086423)
+            abs(self.noise).sum(), 2147755.9753086423)
 
     def test_get_rois(self):
         np.testing.assert_array_almost_equal(
-            self.snr_map.roi_corners, self.ROI_CORNERS_TEST)
+            self.roi_corners, self.ROI_CORNERS_TEST)
         np.testing.assert_array_almost_equal(
-            self.snr_map.image_centre, self.IMAGE_CENTRE_TEST)
-        assert self.snr_map.mask.sum() == 29444
+            self.image_centre, self.IMAGE_CENTRE_TEST)
+        assert self.snr_map_task.mask.sum() == 29444
 
     def test_calc_snr(self):
         np.testing.assert_approx_equal(
-            self.snr_map.snr, 192.8818801790859)
+            self.snr, 192.8818801790859)
 
     def test_calc_snr_map(self):
-        snr_map_cumsum = self.snr_map.snr_map.cumsum().sum()
+        snr_map_cumsum = self.snr_map.cumsum().sum()
 
         print("\ntest_calc_snr_map.py::TestCalcSnrMap::test_calc_snr_map")
         print("new_release_value:", snr_map_cumsum)
@@ -59,13 +65,11 @@ class TestSnrMap(unittest.TestCase):
 
     def test_plot_detailed(self):
         # Just check a valid figure handle is returned
-        fig = self.snr_map.plot_detailed()
-        assert isinstance(fig, matplotlib.figure.Figure)
+        assert isinstance(self.detailed_fig, matplotlib.figure.Figure)
 
     def test_plot_summary(self):
         # Just check a valid figure handle is returned
-        fig = self.snr_map.plot_summary()
-        assert isinstance(fig, matplotlib.figure.Figure)
+        assert isinstance(self.summary_fig, matplotlib.figure.Figure)
 
 
 if __name__ == '__main__':

--- a/tests/test_snr_map.py
+++ b/tests/test_snr_map.py
@@ -22,7 +22,7 @@ class TestSnrMap(unittest.TestCase):
 
     def setUp(self):
         dcms = [self.siemens_1]  # Test on single SNR image
-        self.snr_map = SNRMap(data_paths=dcms, report=True)
+        self.snr_map = SNRMap(input_data=dcms, report=True)
         self.results = self.snr_map.run()
 
     def test_snr_value(self):

--- a/tests/test_spatial_resolution.py
+++ b/tests/test_spatial_resolution.py
@@ -328,24 +328,24 @@ class TestSpatialResolution(unittest.TestCase):
         assert roi.max() == 1.0
 
     def test_get_circles(self):
-        img = rescale_to_byte(self.hazen_spatial_resolution.data[0].pixel_array)
+        img = rescale_to_byte(self.hazen_spatial_resolution.dcm_list[0].pixel_array)
         circles = self.hazen_spatial_resolution.get_circles(img)
         assert np.testing.assert_allclose(circles[0][0][:], self.CIRCLE[0][0][:]) is None
 
     def test_thresh_image(self):
-        img = rescale_to_byte(self.hazen_spatial_resolution.data[0].pixel_array)
+        img = rescale_to_byte(self.hazen_spatial_resolution.dcm_list[0].pixel_array)
         thresh = self.hazen_spatial_resolution.thresh_image(img)
         assert np.count_nonzero(thresh) < np.count_nonzero(img)
 
     def test_find_square(self):
-        img = rescale_to_byte(self.hazen_spatial_resolution.data[0].pixel_array)
+        img = rescale_to_byte(self.hazen_spatial_resolution.dcm_list[0].pixel_array)
         thresh = self.hazen_spatial_resolution.thresh_image(img)
         square, _ = self.hazen_spatial_resolution.find_square(thresh)
 
         assert np.testing.assert_allclose(square, self.TEST_SQUARE) is None
 
     def test_get_bisecting_normals(self):
-        img = rescale_to_byte(self.hazen_spatial_resolution.data[0].pixel_array)
+        img = rescale_to_byte(self.hazen_spatial_resolution.dcm_list[0].pixel_array)
         thresh = self.hazen_spatial_resolution.thresh_image(img)
         square, _ = self.hazen_spatial_resolution.find_square(thresh)
         vector = {"x": square[3][0] - square[0][0], "y": square[3][1] - square[0][1]}
@@ -362,20 +362,20 @@ class TestSpatialResolution(unittest.TestCase):
         assert centre == self.CENTRE
 
     def test_get_void_roi(self):
-        pixels = self.hazen_spatial_resolution.data[0].pixel_array
+        pixels = self.hazen_spatial_resolution.dcm_list[0].pixel_array
         void_arr = self.hazen_spatial_resolution.get_void_roi(pixels, self.CIRCLE)
 
         assert np.mean(void_arr) == self.VOID_MEAN
 
     def test_get_edge_roi(self):
-        pixels = self.hazen_spatial_resolution.data[0].pixel_array
+        pixels = self.hazen_spatial_resolution.dcm_list[0].pixel_array
         edge_arr = self.hazen_spatial_resolution.get_edge_roi(pixels, self.CENTRE)
         assert np.mean(edge_arr) == self.EDGE_MEAN
         edge_arr = self.hazen_spatial_resolution.get_edge_roi(pixels, self.TOP_CENTRE)
         assert np.mean(edge_arr) == self.TOP_EDGE_MEAN
 
     def test_get_signal_roi(self):
-        pixels = self.hazen_spatial_resolution.data[0].pixel_array
+        pixels = self.hazen_spatial_resolution.dcm_list[0].pixel_array
         signal_roi = self.hazen_spatial_resolution.get_signal_roi(pixels, 'right', self.CENTRE, self.CIRCLE)
         assert np.mean(signal_roi) == self.SIGNAL_MEAN
 
@@ -386,10 +386,10 @@ class TestSpatialResolution(unittest.TestCase):
     def test_get_edge(self):
         mean_value = np.mean([self.signal_roi, self.void_roi])
         assert self.x_edge, self.y_edge == self.hazen_spatial_resolution.get_edge(
-            self.edge_roi, mean_value, self.hazen_spatial_resolution.data[0].PixelSpacing)
+            self.edge_roi, mean_value, self.hazen_spatial_resolution.dcm_list[0].PixelSpacing)
 
         assert self.x_edge, self.y_edge == self.hazen_spatial_resolution.get_edge(
-            self.rotated_edge_roi, mean_value, self.hazen_spatial_resolution.data[0].PixelSpacing)
+            self.rotated_edge_roi, mean_value, self.hazen_spatial_resolution.dcm_list[0].PixelSpacing)
 
     def test_get_edge_angle_intercept(self):
         assert self.angle, self.intercept == self.hazen_spatial_resolution.get_edge_angle_and_intercept(
@@ -397,7 +397,7 @@ class TestSpatialResolution(unittest.TestCase):
 
     def test_get_edge_profile_coords(self):
         a, b = self.hazen_spatial_resolution.get_edge_profile_coords(self.angle, self.intercept,
-                                                                     self.hazen_spatial_resolution.data[0].PixelSpacing)
+                                                                     self.hazen_spatial_resolution.dcm_list[0].PixelSpacing)
         assert self.x, self.y == (a.flatten(), b.flatten())
 
     def test_get_esf(self):
@@ -412,7 +412,7 @@ class TestSpatialResolution(unittest.TestCase):
         assert self.mtf[0] == abs(np.fft.fft(self.lsf))[0]
 
     def test_calculate_mtf(self):
-        res = self.hazen_spatial_resolution.calculate_mtf(self.hazen_spatial_resolution.data[0])
+        res = self.hazen_spatial_resolution.calculate_mtf(self.hazen_spatial_resolution.dcm_list[0])
         fe_res = res['frequency_encoding_direction']
         pe_res = res['phase_encoding_direction']
 

--- a/tests/test_spatial_resolution.py
+++ b/tests/test_spatial_resolution.py
@@ -396,12 +396,14 @@ class TestSpatialResolution(unittest.TestCase):
             self.x_edge, self.y_edge)
 
     def test_get_edge_profile_coords(self):
-        a, b = self.hazen_spatial_resolution.get_edge_profile_coords(self.angle, self.intercept,
-                                                                     self.hazen_spatial_resolution.dcm_list[0].PixelSpacing)
+        a, b = self.hazen_spatial_resolution.get_edge_profile_coords(
+                    self.angle, self.intercept,
+                    self.hazen_spatial_resolution.dcm_list[0].PixelSpacing)
         assert self.x, self.y == (a.flatten(), b.flatten())
 
     def test_get_esf(self):
-        assert self.u, self.esf == self.hazen_spatial_resolution.get_esf(self.rotated_edge_roi, self.y)
+        assert self.u, self.esf == self.hazen_spatial_resolution.get_esf(
+                                        self.rotated_edge_roi, self.y)
 
     def test_deri(self):
         a = [round(num, 3) for num in self.lsf]
@@ -412,17 +414,15 @@ class TestSpatialResolution(unittest.TestCase):
         assert self.mtf[0] == abs(np.fft.fft(self.lsf))[0]
 
     def test_calculate_mtf(self):
-        res = self.hazen_spatial_resolution.calculate_mtf(self.hazen_spatial_resolution.dcm_list[0])
-        fe_res = res['frequency encoding direction mm']
-        pe_res = res['phase encoding direction mm']
+        pe_result, fe_result = self.hazen_spatial_resolution.calculate_mtf(
+                                    self.hazen_spatial_resolution.dcm_list[0])
 
         print("\ntest_calculate_mtf.py::TestCalculateMtf::test_calculate_mtf")
-        print("new_release_value:", fe_res)
+        print("new_release_value:", fe_result)
         print("fixed_value:", self.MTF_FE)
 
-
-        assert fe_res == pytest.approx(self.MTF_FE, abs=0.005)
-        assert pe_res == pytest.approx(self.MTF_PE, abs=0.005)
+        assert fe_result == pytest.approx(self.MTF_FE, abs=0.005)
+        assert pe_result == pytest.approx(self.MTF_PE, abs=0.005)
 
 class TestPhilipsResolution(TestSpatialResolution):
     RESOLUTION_DATA = pathlib.Path(TEST_DATA_DIR / 'resolution')

--- a/tests/test_spatial_resolution.py
+++ b/tests/test_spatial_resolution.py
@@ -310,7 +310,7 @@ class TestSpatialResolution(unittest.TestCase):
     bisecting_normal = (273, 257, 313, 263)
 
     def setUp(self) -> None:
-        self.hazen_spatial_resolution = SpatialResolution(data_paths=self.files,
+        self.hazen_spatial_resolution = SpatialResolution(input_data=self.files,
                                                           report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
     def test_get_roi(self):

--- a/tests/test_spatial_resolution.py
+++ b/tests/test_spatial_resolution.py
@@ -413,16 +413,16 @@ class TestSpatialResolution(unittest.TestCase):
 
     def test_calculate_mtf(self):
         res = self.hazen_spatial_resolution.calculate_mtf(self.hazen_spatial_resolution.dcm_list[0])
-        fe_res = res['frequency_encoding_direction']
-        pe_res = res['phase_encoding_direction']
+        fe_res = res['frequency encoding direction mm']
+        pe_res = res['phase encoding direction mm']
 
         print("\ntest_calculate_mtf.py::TestCalculateMtf::test_calculate_mtf")
         print("new_release_value:", fe_res)
         print("fixed_value:", self.MTF_FE)
 
 
-        assert fe_res == pytest.approx(self.MTF_FE)
-        assert pe_res == pytest.approx(self.MTF_PE)
+        assert fe_res == pytest.approx(self.MTF_FE, abs=0.005)
+        assert pe_res == pytest.approx(self.MTF_PE, abs=0.005)
 
 class TestPhilipsResolution(TestSpatialResolution):
     RESOLUTION_DATA = pathlib.Path(TEST_DATA_DIR / 'resolution')

--- a/tests/test_uniformity.py
+++ b/tests/test_uniformity.py
@@ -19,14 +19,11 @@ class TestUniformity(unittest.TestCase):
 
     def test_uniformity(self):
         results = self.uniformity_task.run()
-        key = self.uniformity_task.key(self.uniformity_task.single_dcm)
-        horizontal_ipem = results[key]['horizontal %']
-        vertical_ipem = results[key]['vertical %']
+        horizontal_ipem = results['measurement']['horizontal %']
+        vertical_ipem = results['measurement']['vertical %']
 
         print("\ntest_uniformity.py::TestUniformity::test_uniformity")
-
         print("new_release_value:", vertical_ipem)
-
         print("fixed_value:", self.IPEM_VERTICAL)
 
         assert horizontal_ipem == pytest.approx(self.IPEM_HORIZONTAL, abs=0.005)

--- a/tests/test_uniformity.py
+++ b/tests/test_uniformity.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import unittest
+import pytest
 
 from hazenlib.tasks.uniformity import Uniformity
 from tests import TEST_DATA_DIR, TEST_REPORT_DIR
@@ -12,14 +13,15 @@ class TestUniformity(unittest.TestCase):
     IPEM_VERTICAL = 0.98125
 
     def setUp(self):
-        self.uniformity_task = Uniformity(input_data=os.path.join(self.UNIFORMITY_DATA, 'axial_oil.IMA'),
-                                          report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
+        self.uniformity_task = Uniformity(
+            input_data=os.path.join(self.UNIFORMITY_DATA, 'axial_oil.IMA'),
+            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
     def test_uniformity(self):
         results = self.uniformity_task.run()
         key = self.uniformity_task.key(self.uniformity_task.single_dcm)
-        horizontal_ipem = results[key]['horizontal']
-        vertical_ipem = results[key]['vertical']
+        horizontal_ipem = results[key]['horizontal %']
+        vertical_ipem = results[key]['vertical %']
 
         print("\ntest_uniformity.py::TestUniformity::test_uniformity")
 
@@ -27,16 +29,17 @@ class TestUniformity(unittest.TestCase):
 
         print("fixed_value:", self.IPEM_VERTICAL)
 
-        assert horizontal_ipem == self.IPEM_HORIZONTAL
-        assert vertical_ipem == self.IPEM_VERTICAL
+        assert horizontal_ipem == pytest.approx(self.IPEM_HORIZONTAL, abs=0.005)
+        assert vertical_ipem == pytest.approx(self.IPEM_VERTICAL, abs=0.005)
 
 class TestSagUniformity(TestUniformity):
     IPEM_HORIZONTAL = 0.46875
     IPEM_VERTICAL = 0.5125
 
     def setUp(self):
-        self.uniformity_task = Uniformity(input_data=os.path.join(self.UNIFORMITY_DATA, 'sag.dcm'),
-                                          report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
+        self.uniformity_task = Uniformity(
+            input_data=os.path.join(self.UNIFORMITY_DATA, 'sag.dcm'),
+            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
 
 class TestCorUniformity(TestUniformity):
@@ -44,5 +47,6 @@ class TestCorUniformity(TestUniformity):
     IPEM_VERTICAL = 0.45
 
     def setUp(self):
-        self.uniformity_task = Uniformity(input_data=os.path.join(self.UNIFORMITY_DATA, 'cor.dcm'),
-                                          report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
+        self.uniformity_task = Uniformity(
+            input_data=os.path.join(self.UNIFORMITY_DATA, 'cor.dcm'),
+            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))

--- a/tests/test_uniformity.py
+++ b/tests/test_uniformity.py
@@ -12,12 +12,12 @@ class TestUniformity(unittest.TestCase):
     IPEM_VERTICAL = 0.98125
 
     def setUp(self):
-        self.uniformity_task = Uniformity(data_paths=[os.path.join(self.UNIFORMITY_DATA, 'axial_oil.IMA')],
+        self.uniformity_task = Uniformity(input_data=os.path.join(self.UNIFORMITY_DATA, 'axial_oil.IMA'),
                                           report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
     def test_uniformity(self):
         results = self.uniformity_task.run()
-        key = self.uniformity_task.key(self.uniformity_task.data[0])
+        key = self.uniformity_task.key(self.uniformity_task.single_dcm)
         horizontal_ipem = results[key]['horizontal']
         vertical_ipem = results[key]['vertical']
 
@@ -35,7 +35,7 @@ class TestSagUniformity(TestUniformity):
     IPEM_VERTICAL = 0.5125
 
     def setUp(self):
-        self.uniformity_task = Uniformity(data_paths=[os.path.join(self.UNIFORMITY_DATA, 'sag.dcm')],
+        self.uniformity_task = Uniformity(input_data=os.path.join(self.UNIFORMITY_DATA, 'sag.dcm'),
                                           report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
 
@@ -44,5 +44,5 @@ class TestCorUniformity(TestUniformity):
     IPEM_VERTICAL = 0.45
 
     def setUp(self):
-        self.uniformity_task = Uniformity(data_paths=[os.path.join(self.UNIFORMITY_DATA, 'cor.dcm')],
+        self.uniformity_task = Uniformity(input_data=os.path.join(self.UNIFORMITY_DATA, 'cor.dcm'),
                                           report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))

--- a/tests/test_uniformity.py
+++ b/tests/test_uniformity.py
@@ -14,7 +14,7 @@ class TestUniformity(unittest.TestCase):
 
     def setUp(self):
         self.uniformity_task = Uniformity(
-            input_data=os.path.join(self.UNIFORMITY_DATA, 'axial_oil.IMA'),
+            input_data=[os.path.join(self.UNIFORMITY_DATA, 'axial_oil.IMA')],
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
     def test_uniformity(self):
@@ -35,7 +35,7 @@ class TestSagUniformity(TestUniformity):
 
     def setUp(self):
         self.uniformity_task = Uniformity(
-            input_data=os.path.join(self.UNIFORMITY_DATA, 'sag.dcm'),
+            input_data=[os.path.join(self.UNIFORMITY_DATA, 'sag.dcm')],
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
 
@@ -45,5 +45,5 @@ class TestCorUniformity(TestUniformity):
 
     def setUp(self):
         self.uniformity_task = Uniformity(
-            input_data=os.path.join(self.UNIFORMITY_DATA, 'cor.dcm'),
+            input_data=[os.path.join(self.UNIFORMITY_DATA, 'cor.dcm')],
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))


### PR DESCRIPTION
HazenTask class objects to be initialised with a list of file paths to DICOM images (`input_data: list`), which are then used directly in tasks that process multiple images at once, or a `single_dcm` attribute is being created for tasks that process a single image at a time.

The result dictionary now has a standardised structure, consisting of the following elements:
```
results_dict = {
    "task": "task_name",
    "file": "DCM description or list of descriptions",
    "measurement": {dict of key value pairs},
    "report_image": [OPTIONAL list of paths to report images]
}
```

Furthermore, the values displayed in the result dictionary are being rounded to the appropriate precision and units are displayed in the key.

!!!CHANGE to OUTPUT!!!
The Slice position task now returns only the maximum and average of slice positions, rather than a list of 40 values as previously.

Behind the scene changes for processing the ACR images and slight improvements to the `slice_width` and `snr_map` task scripts.

resolves #374 