### PR TITLE
381 Simplify unit tests for ACR tasks

### DIFF
--- a/hazenlib/ACRObject.py
+++ b/hazenlib/ACRObject.py
@@ -8,6 +8,7 @@ class ACRObject:
     def __init__(self, dcm_list):
         self.dcm_list = dcm_list
         self.images, self.dcms = self.sort_images()
+        self.slice7_dcm = self.dcms[6]
         self.pixel_spacing = self.dcms[0].PixelSpacing
         self.orientation_checks()
         self.rot_angle = self.determine_rotation()

--- a/hazenlib/tasks/acr_geometric_accuracy.py
+++ b/hazenlib/tasks/acr_geometric_accuracy.py
@@ -35,10 +35,10 @@ class ACRGeometricAccuracy(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.ACR_obj = ACRObject(self.dcm_list)
 
     def run(self) -> dict:
-        # Initialise ACR object
-        self.ACR_obj = ACRObject(self.dcm_list)
+        # Identify relevant slices
         slice1_dcm = self.ACR_obj.dcms[0]
         slice5_dcm = self.ACR_obj.dcms[4]
 

--- a/hazenlib/tasks/acr_ghosting.py
+++ b/hazenlib/tasks/acr_ghosting.py
@@ -28,23 +28,20 @@ class ACRGhosting(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.ACR_obj = ACRObject(self.dcm_list)
 
     def run(self) -> dict:
-        # Initialise ACR object
-        self.ACR_obj = ACRObject(self.dcm_list)
-        ghosting_dcm = self.ACR_obj.dcms[6]
-
         # Initialise results dictionary
         results = self.init_result_dict()
-        results['file'] = self.img_desc(ghosting_dcm)
+        results['file'] = self.img_desc(self.ACR_obj.slice7_dcm)
 
         try:
-            result = self.get_signal_ghosting(ghosting_dcm)
+            result = self.get_signal_ghosting(self.ACR_obj.slice7_dcm)
             results['measurement'] = {
                 "signal ghosting %": round(result, 3)
                 }
         except Exception as e:
-            print(f"Could not calculate the percent-signal ghosting for {self.img_desc(ghosting_dcm)} because of : {e}")
+            print(f"Could not calculate the percent-signal ghosting for {self.img_desc(self.ACR_obj.slice7_dcm)} because of : {e}")
             traceback.print_exc(file=sys.stdout)
 
         # only return reports if requested

--- a/hazenlib/tasks/acr_slice_position.py
+++ b/hazenlib/tasks/acr_slice_position.py
@@ -40,10 +40,10 @@ class ACRSlicePosition(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.ACR_obj = ACRObject(self.dcm_list)
 
     def run(self) -> dict:
-        # Initialise ACR object
-        self.ACR_obj = ACRObject(self.dcm_list)
+        # Identify relevant slices
         dcms = [self.ACR_obj.dcms[0], self.ACR_obj.dcms[-1]]
 
         # Initialise results dictionary

--- a/hazenlib/tasks/acr_slice_thickness.py
+++ b/hazenlib/tasks/acr_slice_thickness.py
@@ -28,10 +28,9 @@ from hazenlib.ACRObject import ACRObject
 class ACRSliceThickness(HazenTask):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.ACR_obj = ACRObject(self.dcm_list)
 
     def run(self) -> dict:
-        # Initialise ACR object
-        self.ACR_obj = ACRObject(self.dcm_list)
         slice_thickness_dcm = self.ACR_obj.dcms[0]
 
         # Initialise results dictionary

--- a/hazenlib/tasks/acr_snr.py
+++ b/hazenlib/tasks/acr_snr.py
@@ -22,7 +22,6 @@ from hazenlib.HazenTask import HazenTask
 from scipy import ndimage
 
 import numpy as np
-import skimage.morphology
 import pydicom
 from scipy import ndimage
 
@@ -34,7 +33,7 @@ class ACRSNR(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.ACR_obj = None
+        self.ACR_obj = ACRObject(self.dcm_list)
 
     def run(self, measured_slice_width=None, subtract=None) -> dict:
         
@@ -42,8 +41,7 @@ class ACRSNR(HazenTask):
             measured_slice_width = float(measured_slice_width)
         
         snr_results = {}
-        self.ACR_obj = ACRObject(self.dcm_list)
-        snr_dcm = self.ACR_obj.dcms[6]
+        snr_dcm = self.ACR_obj.slice7_dcm
 
         # SINGLE METHOD (SMOOTHING)
         if subtract is None:
@@ -59,8 +57,8 @@ class ACRSNR(HazenTask):
             temp = [f for f in os.listdir(subtract) if os.path.isfile(os.path.join(subtract, f))]
             filenames = [f'{subtract}/{file}' for file in temp]
 
-            self.data2 = [pydicom.dcmread(dicom) for dicom in filenames]
-            snr_dcm2 = ACRObject(self.data2).dcms[6]
+            data2 = [pydicom.dcmread(dicom) for dicom in filenames]
+            snr_dcm2 = ACRObject(data2).slice7_dcm
             try:
                 snr, normalised_snr = self.snr_by_subtraction(snr_dcm, snr_dcm2)
                 snr_results[f"snr_subtraction_measured_{self.img_desc(snr_dcm)}"] = round(snr, 2)

--- a/hazenlib/tasks/acr_spatial_resolution.py
+++ b/hazenlib/tasks/acr_spatial_resolution.py
@@ -52,16 +52,16 @@ class ACRSpatialResolution(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.ACR_obj = ACRObject(self.dcm_list)
 
     def run(self) -> dict:
-        # Initialise ACR object
-        self.ACR_obj = ACRObject(self.dcm_list)
 
         rot_ang = self.ACR_obj.rot_angle
         if np.abs(rot_ang) < 3:
             logger.warning(f'The estimated rotation angle of the ACR phantom is {np.round(rot_ang, 3)} degrees, which '
                            f'is less than the recommended 3 degrees. Results will be unreliable!')
 
+        # Identify relevant slices
         mtf_dcm = self.ACR_obj.dcms[0]
 
         # Initialise results dictionary

--- a/hazenlib/tasks/acr_uniformity.py
+++ b/hazenlib/tasks/acr_uniformity.py
@@ -29,25 +29,24 @@ class ACRUniformity(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-    def run(self) -> dict:
         # Initialise ACR object
         self.ACR_obj = ACRObject(self.dcm_list)
-        uniformity_dcm = self.ACR_obj.dcms[6]
 
+
+    def run(self) -> dict:
         # Initialise results dictionary
         results = self.init_result_dict()
-        results['file'] = self.img_desc(uniformity_dcm)
+        results['file'] = self.img_desc(self.ACR_obj.slice7_dcm)
 
         try:
-            result = self.get_integral_uniformity(uniformity_dcm)
+            result = self.get_integral_uniformity(self.ACR_obj.slice7_dcm)
             results['measurement'] = {
                 "integral uniformity %": round(result, 2)
                 }
         except Exception as e:
             print(
                 f"Could not calculate the percent integral uniformity for"
-                f"{self.img_desc(uniformity_dcm)} because of : {e}")
+                f"{self.img_desc(self.ACR_obj.slice7_dcm)} because of : {e}")
             traceback.print_exc(file=sys.stdout)
 
         # only return reports if requested

--- a/tests/test_acr_geometric_accuracy.py
+++ b/tests/test_acr_geometric_accuracy.py
@@ -22,9 +22,6 @@ class TestACRGeometricAccuracySiemens(unittest.TestCase):
         self.acr_geometric_accuracy_task = ACRGeometricAccuracy(
             input_data=siemens_files,
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
-        self.acr_geometric_accuracy_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(ACR_DATA_SIEMENS, f'{i}')) for i in
-             os.listdir(ACR_DATA_SIEMENS)])
 
         self.dcm_1 = self.acr_geometric_accuracy_task.ACR_obj.dcms[0]
         self.dcm_5 = self.acr_geometric_accuracy_task.ACR_obj.dcms[4]
@@ -67,9 +64,6 @@ class TestACRGeometricAccuracyGE(TestACRGeometricAccuracySiemens):
         self.acr_geometric_accuracy_task = ACRGeometricAccuracy(
             input_data=ge_files,
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
-        self.acr_geometric_accuracy_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
-             os.listdir(ACR_DATA_GE)])
 
         self.dcm_1 = self.acr_geometric_accuracy_task.ACR_obj.dcms[0]
         self.dcm_5 = self.acr_geometric_accuracy_task.ACR_obj.dcms[4]

--- a/tests/test_acr_ghosting.py
+++ b/tests/test_acr_ghosting.py
@@ -20,14 +20,9 @@ class TestACRGhostingSiemens(unittest.TestCase):
             input_data=siemens_files,
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
-        self.acr_ghosting_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(ACR_DATA_SIEMENS, f'{i}')) for i in
-             os.listdir(ACR_DATA_SIEMENS)])
-
-        self.dcm = self.acr_ghosting_task.ACR_obj.dcms[6]
-
     def test_ghosting(self):
-        ghosting_val = round(self.acr_ghosting_task.get_signal_ghosting(self.dcm), 3)
+        ghosting_val = round(self.acr_ghosting_task.get_signal_ghosting(
+            self.acr_ghosting_task.ACR_obj.slice7_dcm), 3)
 
         print("\ntest_ghosting.py::TestGhosting::test_ghosting")
         print("new_release_value:", ghosting_val)
@@ -36,7 +31,7 @@ class TestACRGhostingSiemens(unittest.TestCase):
         assert ghosting_val == self.psg
 
 
-class TestACRGhostingGE(unittest.TestCase):
+class TestACRGhostingGE(TestACRGhostingSiemens):
     centre = [253, 256]
     psg = 0.471
 
@@ -47,11 +42,3 @@ class TestACRGhostingGE(unittest.TestCase):
         self.acr_ghosting_task = ACRGhosting(
             input_data=ge_files,
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
-        self.acr_ghosting_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
-             os.listdir(ACR_DATA_GE)])
-
-        self.dcm = self.acr_ghosting_task.ACR_obj.dcms[6]
-
-    def test_ghosting(self):
-        assert round(self.acr_ghosting_task.get_signal_ghosting(self.dcm), 3) == self.psg

--- a/tests/test_acr_slice_position.py
+++ b/tests/test_acr_slice_position.py
@@ -19,9 +19,6 @@ class TestACRSlicePositionSiemens(unittest.TestCase):
         siemens_files = get_dicom_files(ACR_DATA_SIEMENS)
 
         self.acr_slice_position_task = ACRSlicePosition(input_data=siemens_files)
-        self.acr_slice_position_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(ACR_DATA_SIEMENS, f'{i}')) for i in
-             os.listdir(ACR_DATA_SIEMENS)])
 
         self.dcm_1 = self.acr_slice_position_task.ACR_obj.dcms[0]
         self.dcm_11 = self.acr_slice_position_task.ACR_obj.dcms[-1]
@@ -59,7 +56,7 @@ class TestACRSlicePositionSiemens(unittest.TestCase):
         assert slice_position_val_11 == self.dL[1]
 
 
-class TestACRSlicePositionGE(unittest.TestCase):
+class TestACRSlicePositionGE(TestACRSlicePositionSiemens):
     x_pts = [(246, 257), (246, 257)]
     y_pts = [(77, 164), (89, 162)]
     dL = 0.41, 0.3
@@ -69,34 +66,6 @@ class TestACRSlicePositionGE(unittest.TestCase):
         ge_files = get_dicom_files(ACR_DATA_GE)
 
         self.acr_slice_position_task = ACRSlicePosition(input_data=ge_files)
-        self.acr_slice_position_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
-             os.listdir(ACR_DATA_GE)])
 
         self.dcm_1 = self.acr_slice_position_task.ACR_obj.dcms[0]
         self.dcm_11 = self.acr_slice_position_task.ACR_obj.dcms[-1]
-
-    def test_wedge_find(self):
-        # IMAGE 1
-        img = self.dcm_1.pixel_array
-        res = self.dcm_1.PixelSpacing
-        mask = self.acr_slice_position_task.ACR_obj.get_mask_image(img)
-        assert (self.acr_slice_position_task.find_wedges(img, mask, res)[0] ==
-                self.x_pts[0]).all() == True
-
-        assert (self.acr_slice_position_task.find_wedges(img, mask, res)[1] ==
-                self.y_pts[0]).all() == True
-
-        # IMAGE 11
-        img = self.dcm_11.pixel_array
-        res = self.dcm_11.PixelSpacing
-        mask = self.acr_slice_position_task.ACR_obj.get_mask_image(img)
-        assert (self.acr_slice_position_task.find_wedges(img, mask, res)[0] ==
-                self.x_pts[1]).all() == True
-
-        assert (self.acr_slice_position_task.find_wedges(img, mask, res)[1] ==
-                self.y_pts[1]).all() == True
-
-    def test_slice_position(self):
-        assert round(self.acr_slice_position_task.get_slice_position(self.dcm_1), 2) == self.dL[0]
-        assert round(self.acr_slice_position_task.get_slice_position(self.dcm_11), 2) == self.dL[1]

--- a/tests/test_acr_slice_thickness.py
+++ b/tests/test_acr_slice_thickness.py
@@ -19,9 +19,6 @@ class TestACRSliceThicknessSiemens(unittest.TestCase):
         siemens_files = get_dicom_files(ACR_DATA_SIEMENS)
 
         self.acr_slice_thickness_task = ACRSliceThickness(input_data=siemens_files)
-        self.acr_slice_thickness_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(ACR_DATA_SIEMENS, f'{i}')) for i in
-             os.listdir(ACR_DATA_SIEMENS)])
 
         self.dcm = self.acr_slice_thickness_task.ACR_obj.dcms[0]
 
@@ -44,7 +41,7 @@ class TestACRSliceThicknessSiemens(unittest.TestCase):
         assert slice_thickness_val == self.dz
 
 
-class TestACRSliceThicknessGE(unittest.TestCase):
+class TestACRSliceThicknessGE(TestACRSliceThicknessSiemens):
     x_pts = [146, 356]
     y_pts = [262, 250]
     dz = 5.02
@@ -54,19 +51,5 @@ class TestACRSliceThicknessGE(unittest.TestCase):
         ge_files = get_dicom_files(ACR_DATA_GE)
 
         self.acr_slice_thickness_task = ACRSliceThickness(input_data=ge_files)
-        self.acr_slice_thickness_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
-             os.listdir(ACR_DATA_GE)])
 
         self.dcm = self.acr_slice_thickness_task.ACR_obj.dcms[0]
-
-    def test_ramp_find(self):
-        res = self.dcm.PixelSpacing
-        centre = self.acr_slice_thickness_task.ACR_obj.centre
-        assert (self.acr_slice_thickness_task.find_ramps(self.dcm.pixel_array, centre, res)[0] ==
-                self.x_pts).all() == True
-        assert (self.acr_slice_thickness_task.find_ramps(self.dcm.pixel_array, centre, res)[1] ==
-                self.y_pts).all() == True
-
-    def test_slice_thickness(self):
-        assert round(self.acr_slice_thickness_task.get_slice_thickness(self.dcm), 2) == self.dz

--- a/tests/test_acr_snr.py
+++ b/tests/test_acr_snr.py
@@ -9,50 +9,6 @@ from hazenlib.ACRObject import ACRObject
 from tests import TEST_DATA_DIR, TEST_REPORT_DIR
 
 
-class TestACRSNRSiemens(unittest.TestCase):
-    norm_factor = 9.761711312090041
-    snr = 344.15
-    sub_snr = 75.94
-
-    def setUp(self):
-        ACR_DATA_SIEMENS = pathlib.Path(TEST_DATA_DIR / 'acr' / 'Siemens')
-        siemens_files = get_dicom_files(ACR_DATA_SIEMENS)
-
-        self.acr_snr_task = ACRSNR(
-            input_data=siemens_files,
-            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
-        self.acr_snr_task.ACR_obj = ACRObject(
-            [pydicom.read_file(
-                os.path.join(TEST_DATA_DIR, 'acr', 'Siemens', f'{i}')) for i in
-                os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens'))
-            ])
-        self.snr_dcm = self.acr_snr_task.ACR_obj.dcms[6]
-        self.snr_dcm2 = ACRObject(
-            [pydicom.read_file(
-                os.path.join(TEST_DATA_DIR, 'acr', 'Siemens2', f'{i}')) for i in
-                os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens2'))
-            ]).dcms[6]
-
-
-    def test_normalisation_factor(self):
-        SNR_factor = self.acr_snr_task.get_normalised_snr_factor(self.snr_dcm)
-        assert SNR_factor == self.norm_factor
-
-    def test_snr_by_smoothing(self):
-        snr, _ = self.acr_snr_task.snr_by_smoothing(self.snr_dcm)
-        assert round(snr, 2) == self.snr
-
-    def test_snr_by_subtraction(self):
-        snr, _ = self.acr_snr_task.snr_by_subtraction(self.snr_dcm, self.snr_dcm2)
-        rounded_snr = round(snr, 2)
-
-        print("\ntest_snr_by_subtraction.py::TestSnrBySubtraction::test_snr_by_subtraction")
-        print("new_release_value:", rounded_snr)
-        print("fixed_value:", self.sub_snr)
-
-        assert rounded_snr == self.sub_snr
-
-
 class TestACRSNRGE(unittest.TestCase):
     norm_factor = 57.12810400630368
     snr = 40.19
@@ -64,16 +20,44 @@ class TestACRSNRGE(unittest.TestCase):
         self.acr_snr_task = ACRSNR(
             input_data=ge_files,
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
-        self.acr_snr_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'GE', f'{i}')) for i in
-             os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'GE'))])
 
-        self.dcm = self.acr_snr_task.ACR_obj.dcms[6]
+        self.snr_dcm = self.acr_snr_task.ACR_obj.dcms[6]
 
     def test_normalisation_factor(self):
-        SNR_factor = self.acr_snr_task.get_normalised_snr_factor(self.dcm)
+        SNR_factor = self.acr_snr_task.get_normalised_snr_factor(self.snr_dcm)
         assert SNR_factor == self.norm_factor
 
     def test_snr_by_smoothing(self):
-        snr, _ = self.acr_snr_task.snr_by_smoothing(self.dcm)
+        snr, _ = self.acr_snr_task.snr_by_smoothing(self.snr_dcm)
         assert round(snr, 2) == self.snr
+
+
+class TestACRSNRSiemens(TestACRSNRGE):
+    norm_factor = 9.761711312090041
+    snr = 344.15
+    sub_snr = 75.94
+
+    def setUp(self):
+        ACR_DATA_SIEMENS = pathlib.Path(TEST_DATA_DIR / 'acr' / 'Siemens')
+        siemens_files = get_dicom_files(ACR_DATA_SIEMENS)
+
+        self.acr_snr_task = ACRSNR(
+            input_data=siemens_files,
+            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
+
+        self.snr_dcm = self.acr_snr_task.ACR_obj.dcms[6]
+        self.snr_dcm2 = ACRObject(
+            [pydicom.read_file(
+                os.path.join(TEST_DATA_DIR, 'acr', 'Siemens2', f'{i}')) for i in
+                os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'Siemens2'))
+            ]).dcms[6]
+
+    def test_snr_by_subtraction(self):
+        snr, _ = self.acr_snr_task.snr_by_subtraction(self.snr_dcm, self.snr_dcm2)
+        rounded_snr = round(snr, 2)
+
+        print("\ntest_snr_by_subtraction.py::TestSnrBySubtraction::test_snr_by_subtraction")
+        print("new_release_value:", rounded_snr)
+        print("fixed_value:", self.sub_snr)
+
+        assert rounded_snr == self.sub_snr

--- a/tests/test_acr_spatial_resolution.py
+++ b/tests/test_acr_spatial_resolution.py
@@ -21,27 +21,27 @@ class TestACRSpatialResolutionSiemens(unittest.TestCase):
     MTF50 = (1.18, 1.35)
 
     def setUp(self):
-        ACR_DATA_SIEMENS = pathlib.Path(TEST_DATA_DIR / 'acr' / 'Siemens')
+        ACR_DATA_SIEMENS = pathlib.Path(TEST_DATA_DIR / 'acr' / 'SiemensMTF')
         siemens_files = get_dicom_files(ACR_DATA_SIEMENS)
 
         self.acr_spatial_resolution_task = ACRSpatialResolution(
             input_data=siemens_files,
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
-        self.acr_spatial_resolution_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(TEST_DATA_DIR, 'acr', 'SiemensMTF', f'{i}')) for i in
-             os.listdir(os.path.join(TEST_DATA_DIR, 'acr', 'SiemensMTF'))])
 
         self.dcm = self.acr_spatial_resolution_task.ACR_obj.dcms[0]
         self.crop_image = self.acr_spatial_resolution_task.crop_image(
             self.dcm.pixel_array, self.centre[0], self.y_ramp_pos, self.width)
+        self.data = self.dcm.pixel_array
+        self.res = self.dcm.PixelSpacing
 
     def test_find_y_ramp(self):
-        data = self.dcm.pixel_array
-        res = self.dcm.PixelSpacing
-        assert self.acr_spatial_resolution_task.y_position_for_ramp(res, data, self.centre) == self.y_ramp_pos
+        y_ramp_pos = self.acr_spatial_resolution_task.y_position_for_ramp(
+                            self.res, self.data, self.centre)
+        assert y_ramp_pos == self.y_ramp_pos
 
     def test_get_edge_type(self):
-        assert self.acr_spatial_resolution_task.get_edge_type(self.crop_image) == self.edge_type
+        edge_type = self.acr_spatial_resolution_task.get_edge_type(self.crop_image)
+        assert edge_type == self.edge_type
 
     def test_get_edge_loc(self):
         assert (self.acr_spatial_resolution_task.edge_location_for_plot(self.crop_image, self.edge_type[0] ==
@@ -79,9 +79,6 @@ class TestACRSpatialResolutionGE(TestACRSpatialResolutionSiemens):
         self.acr_spatial_resolution_task = ACRSpatialResolution(
             input_data=ge_files,
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
-        self.acr_spatial_resolution_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
-             os.listdir(ACR_DATA_GE)])
 
         self.dcm = self.acr_spatial_resolution_task.ACR_obj.dcms[0]
         self.crop_image = self.acr_spatial_resolution_task.crop_image(

--- a/tests/test_acr_spatial_resolution.py
+++ b/tests/test_acr_spatial_resolution.py
@@ -83,3 +83,5 @@ class TestACRSpatialResolutionGE(TestACRSpatialResolutionSiemens):
         self.dcm = self.acr_spatial_resolution_task.ACR_obj.dcms[0]
         self.crop_image = self.acr_spatial_resolution_task.crop_image(
             self.dcm.pixel_array, self.centre[0], self.y_ramp_pos, self.width)
+        self.data = self.dcm.pixel_array
+        self.res = self.dcm.PixelSpacing

--- a/tests/test_acr_uniformity.py
+++ b/tests/test_acr_uniformity.py
@@ -20,14 +20,10 @@ class TestACRUniformitySiemens(unittest.TestCase):
             input_data=siemens_files,
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
 
-        self.acr_uniformity_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(ACR_DATA_SIEMENS, f'{i}')) for i in
-             os.listdir(ACR_DATA_SIEMENS)])
-
-        self.dcm = self.acr_uniformity_task.ACR_obj.dcms[6]
 
     def test_uniformity(self):
-        results = self.acr_uniformity_task.get_integral_uniformity(self.dcm)
+        results = self.acr_uniformity_task.get_integral_uniformity(
+            self.acr_uniformity_task.ACR_obj.slice7_dcm)
         rounded_results = round(results, 2)
 
         print("\ntest_uniformity.py::TestUniformity::test_uniformity")
@@ -39,7 +35,7 @@ class TestACRUniformitySiemens(unittest.TestCase):
 
 # TODO: Add unit tests for Philips datasets.
 
-class TestACRUniformityGE(unittest.TestCase):
+class TestACRUniformityGE(TestACRUniformitySiemens):
     piu = 85.17
 
     def setUp(self):
@@ -49,12 +45,4 @@ class TestACRUniformityGE(unittest.TestCase):
         self.acr_uniformity_task = ACRUniformity(
             input_data=ge_files,
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR))
-        self.acr_uniformity_task.ACR_obj = ACRObject(
-            [pydicom.read_file(os.path.join(ACR_DATA_GE, f'{i}')) for i in
-             os.listdir(ACR_DATA_GE)])
 
-        self.dcm = self.acr_uniformity_task.ACR_obj.dcms[6]
-
-    def test_uniformity(self):
-        results = self.acr_uniformity_task.get_integral_uniformity(self.dcm)
-        assert round(results, 2) == self.piu


### PR DESCRIPTION
Use the ability to inherit unit test logic from TestClass and apply it to ACR datasets from different scanner manufacturers.