### PR TITLE
386 Verbose option for slice position

### DIFF
--- a/hazenlib/HazenTask.py
+++ b/hazenlib/HazenTask.py
@@ -10,7 +10,7 @@ import os
 
 class HazenTask:
 
-    def __init__(self, input_data: list, report: bool = False, report_dir=None):
+    def __init__(self, input_data: list, report: bool = False, report_dir=None, **kwargs):
         data_paths = sorted(input_data)
         self.dcm_list = [dcmread(dicom)for dicom in data_paths]
         self.report: bool = report

--- a/hazenlib/__init__.py
+++ b/hazenlib/__init__.py
@@ -95,7 +95,7 @@ Usage:
 General Options: available for all Tasks
     --report                     Whether to generate visualisation of the measurement steps.
     --output=<path>              Provide a folder where report images are to be saved.
-    --verbose                    Whether to provide additional metadata about the calculation in the result
+    --verbose                    Whether to provide additional metadata about the calculation in the result (slice position and relaxometry tasks)
     --log=<level>                Set the level of logging based on severity. Available levels are "debug", "warning", "error", "critical", with "info" as default.
 
 acr_snr & snr Task options:
@@ -206,11 +206,10 @@ def main():
         result = task.run()
     elif arguments['relaxometry'] or arguments['<task>'] == 'relaxometry':
         selected_task = 'relaxometry'
-        task = init_task(selected_task, files, report, report_dir,
-                    calc = arguments['--calc'],
+        task = init_task(selected_task, files, report, report_dir)
+        result = task.run(calc = arguments['--calc'],
                     plate_number = arguments['--plate_number'], 
                     verbose = arguments['--verbose'])
-        result = task.run()
     else:
         selected_task = arguments['<task>']
         if selected_task in single_image_tasks:

--- a/hazenlib/__init__.py
+++ b/hazenlib/__init__.py
@@ -196,20 +196,20 @@ def main():
     if arguments['snr'] or arguments['<task>'] == 'snr':
         selected_task = 'snr'
         task = init_task(selected_task, files, report, report_dir,
-                    measured_slice_width=arguments['--measured_slice_width'])
+                         measured_slice_width=arguments['--measured_slice_width'])
         result = task.run()
     elif arguments['acr_snr'] or arguments['<task>'] == 'acr_snr':
         selected_task = 'acr_snr'
         task = init_task(selected_task, files, report, report_dir,
-                    subtract=arguments['--subtract'],
-                    measured_slice_width=arguments['--measured_slice_width'])
+                         subtract=arguments['--subtract'],
+                         measured_slice_width=arguments['--measured_slice_width'])
         result = task.run()
     elif arguments['relaxometry'] or arguments['<task>'] == 'relaxometry':
         selected_task = 'relaxometry'
         task = init_task(selected_task, files, report, report_dir)
-        result = task.run(calc = arguments['--calc'],
-                    plate_number = arguments['--plate_number'], 
-                    verbose = arguments['--verbose'])
+        result = task.run(calc=arguments['--calc'],
+                          plate_number=arguments['--plate_number'],
+                          verbose=arguments['--verbose'])
     else:
         selected_task = arguments['<task>']
         if selected_task in single_image_tasks:
@@ -223,7 +223,7 @@ def main():
         else:
             # Slice Position task, all ACR tasks except SNR
             task = init_task(selected_task, files, report, report_dir,
-                    verbose=verbose)
+                             verbose=verbose)
             result = task.run()
 
     result_string = json.dumps(result, indent=2)

--- a/hazenlib/__init__.py
+++ b/hazenlib/__init__.py
@@ -214,6 +214,7 @@ def main():
     else:
         selected_task = arguments['<task>']
         if selected_task in single_image_tasks:
+            # Ghosting, Uniformity, Spatial resolution, SNR map, Slice width
             for file in files:
                 task = init_task(selected_task, [file], report, report_dir)
                 result = task.run()
@@ -221,7 +222,9 @@ def main():
                 print(result_string)
             return
         else:
-            task = init_task(selected_task, files, report, report_dir, verbose)
+            # Slice Position task, all ACR tasks except SNR
+            task = init_task(selected_task, files, report, report_dir,
+                    verbose=verbose)
             result = task.run()
 
     result_string = json.dumps(result, indent=2)

--- a/hazenlib/__init__.py
+++ b/hazenlib/__init__.py
@@ -87,7 +87,7 @@ Usage:
     hazen <task> <folder> [options]
     hazen snr <folder> [--measured_slice_width=<mm>] [options]
     hazen acr_snr <folder> [--measured_slice_width=<mm>] [--subtract=<folder2>] [options]
-    hazen relaxometry <folder> --calc=<T1> --plate_number=<4> [--verbose] [options]
+    hazen relaxometry <folder> --calc=<T1> --plate_number=<4> [options]
 
     hazen -h | --help
     hazen --version
@@ -95,6 +95,7 @@ Usage:
 General Options: available for all Tasks
     --report                     Whether to generate visualisation of the measurement steps.
     --output=<path>              Provide a folder where report images are to be saved.
+    --verbose                    Whether to provide additional metadata about the calculation in the result
     --log=<level>                Set the level of logging based on severity. Available levels are "debug", "warning", "error", "critical", with "info" as default.
 
 acr_snr & snr Task options:
@@ -104,7 +105,6 @@ acr_snr & snr Task options:
 relaxometry Task options:
     --calc=<n>                   Choose 'T1' or 'T2' for relaxometry measurement (required)
     --plate_number=<n>           Which plate to use for measurement: 4 or 5 (required)
-    --verbose                    Whether to provide additional metadata about the calculation in the result (optional)
 """
 
 
@@ -115,7 +115,6 @@ import json
 import sys
 
 from docopt import docopt
-from hazenlib.logger import logger
 from hazenlib.utils import get_dicom_files
 from hazenlib._version import __version__
 
@@ -135,12 +134,25 @@ single_image_tasks = ["ghosting", "uniformity", "spatial_resolution",
                       "slice_width", "snr_map"]
 
 
-def init_task(selected_task, files, report, report_dir):
+def init_task(selected_task, files, report, report_dir, **kwargs):
+    """Initialise object of the correct HazenTask class
+
+    Args:
+        selected_task (string): name of task script/module to load
+        files (list): list of filepaths to DICOM images
+        report (bool): whether to generate report images
+        report_dir (string): path to folder to save report images to
+        kwargs: any other key word arguments
+
+    Returns:
+        an object of the specified HazenTask class
+    """
     task_module = importlib.import_module(f"hazenlib.tasks.{selected_task}")
-    
+
     try:
         task = getattr(task_module, selected_task.capitalize())(
-            input_data=files, report=report, report_dir=report_dir)
+            input_data=files, report=report, report_dir=report_dir,
+            **kwargs)
     except:
         class_list = [cls.__name__ for _, cls in inspect.getmembers(
             sys.modules[task_module.__name__],
@@ -148,7 +160,8 @@ def init_task(selected_task, files, report, report_dir):
             )]
         if len(class_list) == 1:
             task = getattr(task_module, class_list[0])(
-                input_data=files, report=report, report_dir=report_dir)
+                input_data=files, report=report, report_dir=report_dir,
+                **kwargs)
         else:
             raise Exception(
                 f'Task {task_module} has multiple class definitions: {class_list}')
@@ -177,34 +190,27 @@ def main():
 
     report = arguments['--report']
     report_dir = arguments['--output'] if arguments['--output'] else None
+    verbose = arguments['--verbose']
 
     # Parse the task and optional arguments:
     if arguments['snr'] or arguments['<task>'] == 'snr':
         selected_task = 'snr'
-        task = init_task(selected_task, files, report, report_dir)
-        result = task.run(
-                measured_slice_width = arguments['--measured_slice_width'])
+        task = init_task(selected_task, files, report, report_dir,
+                    measured_slice_width=arguments['--measured_slice_width'])
+        result = task.run()
     elif arguments['acr_snr'] or arguments['<task>'] == 'acr_snr':
         selected_task = 'acr_snr'
-        task = init_task(selected_task, files, report, report_dir)
-        result = task.run(
-                subtract = arguments['--subtract'],
-                measured_slice_width = arguments['--measured_slice_width'])
+        task = init_task(selected_task, files, report, report_dir,
+                    subtract=arguments['--subtract'],
+                    measured_slice_width=arguments['--measured_slice_width'])
+        result = task.run()
     elif arguments['relaxometry'] or arguments['<task>'] == 'relaxometry':
-        # TODO: Refactor Relaxometry task into HazenTask object
-        #  - Relaxometry not currently converted to HazenTask object
-        #  - Relaxometry task accessible via CLI using the old syntax until it can be refactored
-        # relax_task = importlib.import_module(f"hazenlib.relaxometry")
-        # dicom_objects = [pydicom.read_file(x, force=True) for x in files if is_dicom_file(x)]
-        # relaxometry_args = parse_relaxometry_args(arguments)
-        # result = relax_task.main(dicom_objects, **relaxometry_args,
-        #                         report=report, report_dir=report_dir)
         selected_task = 'relaxometry'
-        task = init_task(selected_task, files, report, report_dir)
-        result = task.run(
+        task = init_task(selected_task, files, report, report_dir,
                     calc = arguments['--calc'],
                     plate_number = arguments['--plate_number'], 
                     verbose = arguments['--verbose'])
+        result = task.run()
     else:
         selected_task = arguments['<task>']
         if selected_task in single_image_tasks:
@@ -215,7 +221,7 @@ def main():
                 print(result_string)
             return
         else:
-            task = init_task(selected_task, files, report, report_dir)
+            task = init_task(selected_task, files, report, report_dir, verbose)
             result = task.run()
 
     result_string = json.dumps(result, indent=2)

--- a/hazenlib/tasks/acr_snr.py
+++ b/hazenlib/tasks/acr_snr.py
@@ -34,23 +34,30 @@ class ACRSNR(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.ACR_obj = None
+        # measured slice width is expected to be a floating point number
+        try:
+            self.measured_slice_width = float(kwargs["measured_slice_width"])
+        except:
+            self.measured_slice_width = None
 
-    def run(self, measured_slice_width=None, subtract=None) -> dict:
-        
-        if measured_slice_width is not None:
-            measured_slice_width = float(measured_slice_width)
-        
+        # subtract is expected to be a path to a folder
+        try:
+            if os.path.isdir(kwargs["subtract"]):
+                self.subtract = kwargs["subtract"]
+        except:
+            self.subtract = None
+
+    def run(self) -> dict:
         self.ACR_obj = ACRObject(self.dcm_list)
         snr_dcm = self.ACR_obj.dcms[6]
         # Initialise results dictionary
         results = self.init_result_dict()
 
         # SINGLE METHOD (SMOOTHING)
-        if subtract is None:
+        if self.subtract is None:
             try:
                 results['file'] = self.img_desc(snr_dcm)
-                snr, normalised_snr = self.snr_by_smoothing(snr_dcm, measured_slice_width)
+                snr, normalised_snr = self.snr_by_smoothing(snr_dcm, self.measured_slice_width)
                 results['measurement']['snr by smoothing'] = {
                     "measured": round(snr, 2),
                     "normalised": round(normalised_snr, 2)
@@ -60,14 +67,15 @@ class ACRSNR(HazenTask):
                 traceback.print_exc(file=sys.stdout)
         # SUBTRACTION METHOD
         else:
-            temp = [f for f in os.listdir(subtract) if os.path.isfile(os.path.join(subtract, f))]
-            filenames = [f'{subtract}/{file}' for file in temp]
-
-            self.data2 = [pydicom.dcmread(dicom) for dicom in filenames]
+            # Get the absolute path to all FILES found in the directory provided
+            filepaths = [os.path.join(self.subtract, f) for f in os.listdir(self.subtract) \
+                        if os.path.isfile(os.path.join(self.subtract, f))]
+            self.data2 = [pydicom.dcmread(dicom) for dicom in filepaths]
             snr_dcm2 = ACRObject(self.data2).dcms[6]
             results['file'] = [self.img_desc(snr_dcm), self.img_desc(snr_dcm2)]
             try:
-                snr, normalised_snr = self.snr_by_subtraction(snr_dcm, snr_dcm2, measured_slice_width)
+                snr, normalised_snr = self.snr_by_subtraction(
+                                snr_dcm, snr_dcm2, self.measured_slice_width)
                 results['measurement']['snr by subtraction'] = {
                     "measured": round(snr, 2),
                     "normalised": round(normalised_snr, 2)

--- a/hazenlib/tasks/acr_snr.py
+++ b/hazenlib/tasks/acr_snr.py
@@ -33,6 +33,7 @@ class ACRSNR(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.ACR_obj = ACRObject(self.dcm_list)
         # measured slice width is expected to be a floating point number
         try:
             self.measured_slice_width = float(kwargs["measured_slice_width"])
@@ -47,7 +48,6 @@ class ACRSNR(HazenTask):
             self.subtract = None
 
     def run(self) -> dict:
-        self.ACR_obj = ACRObject(self.dcm_list)
         snr_dcm = self.ACR_obj.slice7_dcm
         # Initialise results dictionary
         results = self.init_result_dict()

--- a/hazenlib/tasks/relaxometry.py
+++ b/hazenlib/tasks/relaxometry.py
@@ -329,7 +329,7 @@ class Relaxometry(HazenTask):
                 calc_times=image_stack.relax_times,
                 frac_time_difference=frac_time_diff.tolist())
             # , output_graphics=output_files_path
-            results['metadata'] = metadata
+            results['additional data'] = metadata
 
             detailed_output['measurement details'] = {
                 'Echo Time': [im.EchoTime for im in image_stack.images],

--- a/hazenlib/tasks/slice_position.py
+++ b/hazenlib/tasks/slice_position.py
@@ -22,6 +22,10 @@ class SlicePosition(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        if "verbose" in kwargs.keys():
+            self.verbose = kwargs["verbose"]
+        else:
+            self.verbose = False
 
     def run(self) -> dict:
         if len(self.dcm_list) != 60:
@@ -36,6 +40,11 @@ class SlicePosition(HazenTask):
 
         try:
             position_errors = self.slice_position_error(truncated_data)
+            if self.verbose:
+                rounded_positions = [round(pos, 3) for pos in position_errors]
+                results['additional values'] = {
+                    "slice positions": rounded_positions
+                }
 
             # Round calculated values to the appropriate decimal places
             max_pos = round(np.max(position_errors), 2)

--- a/hazenlib/tasks/slice_position.py
+++ b/hazenlib/tasks/slice_position.py
@@ -42,7 +42,7 @@ class SlicePosition(HazenTask):
             position_errors = self.slice_position_error(truncated_data)
             if self.verbose:
                 rounded_positions = [round(pos, 3) for pos in position_errors]
-                results['additional values'] = {
+                results['additional data'] = {
                     "slice positions": rounded_positions
                 }
 

--- a/hazenlib/tasks/snr.py
+++ b/hazenlib/tasks/snr.py
@@ -28,10 +28,10 @@ class SNR(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        if "measured_slice_width" in kwargs.keys():
-            if kwargs["measured_slice_width"] is not None:
-                self.measured_slice_width = float(kwargs["measured_slice_width"])
-        else:
+        # measured slice width is expected to be a floating point number
+        try:
+            self.measured_slice_width = float(kwargs["measured_slice_width"])
+        except:
             self.measured_slice_width = None
 
     def run(self) -> dict:

--- a/hazenlib/tasks/snr.py
+++ b/hazenlib/tasks/snr.py
@@ -28,10 +28,13 @@ class SNR(HazenTask):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        if "measured_slice_width" in kwargs.keys():
+            if kwargs["measured_slice_width"] is not None:
+                self.measured_slice_width = float(kwargs["measured_slice_width"])
+        else:
+            self.measured_slice_width = None
 
-    def run(self, measured_slice_width=None) -> dict:
-        if measured_slice_width is not None:
-            measured_slice_width = float(measured_slice_width)
+    def run(self) -> dict:
         
         results = self.init_result_dict()
         results['file'] = [self.img_desc(img) for img in self.dcm_list]
@@ -39,7 +42,7 @@ class SNR(HazenTask):
 
         if len(self.dcm_list) == 2:
             snr, normalised_snr = self.snr_by_subtraction(
-                self.dcm_list[0], self.dcm_list[1], measured_slice_width
+                self.dcm_list[0], self.dcm_list[1], self.measured_slice_width
                 )
             results['measurement']["snr by subtraction"] = {
                     "measured": round(snr, 2),
@@ -47,7 +50,7 @@ class SNR(HazenTask):
                 }
 
         for idx, dcm in enumerate(self.dcm_list):
-            snr, normalised_snr = self.snr_by_smoothing(dcm, measured_slice_width)
+            snr, normalised_snr = self.snr_by_smoothing(dcm, self.measured_slice_width)
             results['measurement']["snr by smoothing"][self.img_desc(dcm)] = {
                     "measured": round(snr, 2),
                     "normalised": round(normalised_snr, 2)

--- a/tests/test_hazenlib.py
+++ b/tests/test_hazenlib.py
@@ -38,8 +38,8 @@ class TestCliParser(unittest.TestCase):
     def test_snr_measured_slice_width(self):
         path = str(TEST_DATA_DIR / 'snr' / 'GE')
         files = get_dicom_files(path)
-        snr_task = SNR(input_data=files, report=False)
-        result = snr_task.run(measured_slice_width=5)
+        snr_task = SNR(input_data=files, report=False, measured_slice_width=5)
+        result = snr_task.run()
 
         dict1 = {
             "task": "SNR",

--- a/tests/test_relaxometry.py
+++ b/tests/test_relaxometry.py
@@ -491,7 +491,7 @@ class TestRelaxometry(unittest.TestCase):
         task = Relaxometry(input_data=dcms)
         results = task.run(plate_number=5, calc="T1", verbose=True)
         np.testing.assert_allclose(
-                    results['metadata']['calc_times'], self.PLATE5_T1,
+                    results['additional data']['calc_times'], self.PLATE5_T1,
                     rtol=0.02, atol=1)
 
     def test_t1_p4_philips(self):
@@ -502,7 +502,7 @@ class TestRelaxometry(unittest.TestCase):
         task = Relaxometry(input_data=dcms)
         results = task.run(plate_number=4, calc="T1", verbose=True)
         np.testing.assert_allclose(
-                    results['metadata']['calc_times'], self.SITE4_T1_P4,
+                    results['additional data']['calc_times'], self.SITE4_T1_P4,
                     rtol=0.02, atol=1)
 
     def test_t1_p5_philips(self):
@@ -513,7 +513,7 @@ class TestRelaxometry(unittest.TestCase):
         task = Relaxometry(input_data=dcms)
         results = task.run(plate_number=5, calc="T1", verbose=True)
         np.testing.assert_allclose(
-                    results['metadata']['calc_times'], self.SITE4_T1_P5,
+                    results['additional data']['calc_times'], self.SITE4_T1_P5,
                     rtol=0.02, atol=1)
 
     def test_t2_p4_philips(self):
@@ -524,7 +524,7 @@ class TestRelaxometry(unittest.TestCase):
         task = Relaxometry(input_data=dcms)
         results = task.run(plate_number=4, calc="T2", verbose=True)
         np.testing.assert_allclose(
-                    results['metadata']['calc_times'], self.SITE4_T2_P4,
+                    results['additional data']['calc_times'], self.SITE4_T2_P4,
                     rtol=0.02, atol=1)
 
     def test_t2_p5_philips(self):
@@ -535,7 +535,7 @@ class TestRelaxometry(unittest.TestCase):
         task = Relaxometry(input_data=dcms)
         results = task.run(plate_number=5, calc="T2", verbose=True)
         np.testing.assert_allclose(
-                    results['metadata']['calc_times'], self.SITE4_T2_P5,
+                    results['additional data']['calc_times'], self.SITE4_T2_P5,
                     rtol=0.02, atol=1)
 
     def test_scale_up_template(self):
@@ -569,7 +569,7 @@ class TestRelaxometry(unittest.TestCase):
                 results = task.run(plate_number=plate,
                                 calc = tparam, verbose=True)
                 np.testing.assert_allclose(
-                    results['metadata']['calc_times'],
+                    results['additional data']['calc_times'],
                     getattr(self, f'SITE3_{tparam}_P{plate}_VALS'),
                     rtol=0.02, atol=1)
 
@@ -589,7 +589,7 @@ class TestRelaxometry(unittest.TestCase):
         task = Relaxometry(input_data=dcms)
         results = task.run(plate_number=4, calc="T1", verbose=True)
         np.testing.assert_allclose(
-                    results['metadata']['calc_times'], self.SITE5_T1_P4,
+                    results['additional data']['calc_times'], self.SITE5_T1_P4,
                     rtol=0.02, atol=1)
 
         # T1 plate 5
@@ -599,7 +599,7 @@ class TestRelaxometry(unittest.TestCase):
         task = Relaxometry(input_data=dcms)
         results = task.run(plate_number=5, calc="T1", verbose=True)
         np.testing.assert_allclose(
-                    results['metadata']['calc_times'], self.SITE5_T1_P5,
+                    results['additional data']['calc_times'], self.SITE5_T1_P5,
                     rtol=0.02, atol=1)
 
         # T2 plate 4
@@ -609,7 +609,7 @@ class TestRelaxometry(unittest.TestCase):
         task = Relaxometry(input_data=dcms)
         results = task.run(plate_number=4, calc="T2", verbose=True)
         np.testing.assert_allclose(
-                    results['metadata']['calc_times'], self.SITE5_T2_P4,
+                    results['additional data']['calc_times'], self.SITE5_T2_P4,
                     rtol=0.02, atol=1)
 
         # T2 plate 5
@@ -619,7 +619,7 @@ class TestRelaxometry(unittest.TestCase):
         task = Relaxometry(input_data=dcms)
         results = task.run(plate_number=5, calc="T2", verbose=True)
         np.testing.assert_allclose(
-                    results['metadata']['calc_times'], self.SITE5_T2_P5,
+                    results['additional data']['calc_times'], self.SITE5_T2_P5,
                     rtol=0.02, atol=1)
 
 


### PR DESCRIPTION
General improvement to the way of passing key word arguments from the CLI to the relevant HazenTask class (rather than to its `.run()` function.
Add CLI option to slice position task to display the rounded positions for all 40 slices with `--verbose`