### PR TITLE
rotates sagittal acr images

### DIFF
--- a/hazenlib/ACRObject.py
+++ b/hazenlib/ACRObject.py
@@ -50,7 +50,6 @@ class ACRObject:
         logger.info("image orientation is %s", orientation)
         dcm_stack = [dcm_list[i] for i in np.argsort(positions)]
         # img_stack = [dcm.pixel_array for dcm in dcm_stack]
-
         return dcm_stack  # , img_stack
 
     def order_phantom_slices(self, dcm_list):

--- a/hazenlib/tasks/acr_slice_thickness.py
+++ b/hazenlib/tasks/acr_slice_thickness.py
@@ -24,6 +24,8 @@ import skimage.measure
 
 from hazenlib.HazenTask import HazenTask
 from hazenlib.ACRObject import ACRObject
+from hazenlib.utils import get_image_orientation
+
 
 
 class ACRSliceThickness(HazenTask):
@@ -43,6 +45,19 @@ class ACRSliceThickness(HazenTask):
         """
         # Identify relevant slice
         slice_thickness_dcm = self.ACR_obj.slice_stack[0]
+        # TODO image may be 90 degrees cw or acw, could use code to identify which or could be added as extra arg
+
+        ori = get_image_orientation(slice_thickness_dcm)
+        if ori == 'Sagittal':
+            # Get the pixel array from the DICOM file
+            img = slice_thickness_dcm.pixel_array
+
+            # Rotate the image 90 degrees clockwise
+
+            rotated_img = np.rot90(img, k=-1)  # k=-1 for 90 degrees clockwise
+
+            # Update the pixel array in the DICOM object
+            slice_thickness_dcm.PixelData = rotated_img.tobytes()
 
         # Initialise results dictionary
         results = self.init_result_dict()

--- a/tests/test_ACRObject.py
+++ b/tests/test_ACRObject.py
@@ -90,7 +90,7 @@ class TestACRToolsCOR(TestACRTools):
         self.img7 = self.ACR_object.slice_stack[6].pixel_array
 
 
-# Siemens saggital
+# Siemens sagittal
 class TestACRToolsSAG(TestACRTools):
     rotation = -90.0
     centre = (130, 148)

--- a/tests/test_acr_geometric_accuracy.py
+++ b/tests/test_acr_geometric_accuracy.py
@@ -57,10 +57,7 @@ class TestACRGeometricAccuracySiemens(unittest.TestCase):
         metrics = np.round(metrics, 2)
         assert (metrics == self.distortion_metrics).all() == True
 
-
-# TODO: Add unit tests for Philips datasets.
-
-
+# TODO: Add unit tests for Philips datasets (when Philips data is available).
 class TestACRGeometricAccuracyGE(TestACRGeometricAccuracySiemens):
     ACR_DATA = pathlib.Path(TEST_DATA_DIR / "acr" / "GE")
     L1 = 190.42, 188.9


### PR DESCRIPTION
Rotates the slice thickness image 90 degrees clockwise if the image orientation is determined to be sagittal. Only works if original image is rotated 90 degrees anticlockwise.