### PR TITLE
Added Python 3.13 to CI workflows

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.9', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests_development.yml
+++ b/.github/workflows/tests_development.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.9', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/tests_release.yml
+++ b/.github/workflows/tests_release.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.9', '3.10', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ long_description_content_type = text/markdown
 
 [options]
 packages = find:
-python_requires = >=3.9,<3.13
+python_requires = >=3.9,<3.14
 install_requires =
     pydicom==2.4.1
     numpy>=1.26.0


### PR DESCRIPTION
- Added Python 3.13 to CI workflows.
- Added Python 3.10, 3.11 to CI workflows - where missing.
- Default to publishing with Python 3.13
- Closes #463
- Closes #454