### PR TITLE
fix: ignore .DS_Store files in subtract directory

### DIFF
--- a/hazenlib/tasks/acr_snr.py
+++ b/hazenlib/tasks/acr_snr.py
@@ -134,7 +134,10 @@ class ACRSNR(HazenTask):
             filepaths = [
                 os.path.join(self.subtract, f)
                 for f in os.listdir(self.subtract)
-                if os.path.isfile(os.path.join(self.subtract, f))
+                if (
+                    os.path.isfile(os.path.join(self.subtract, f))
+                    and ".DS_Store" not in f
+                )
             ]
             data2 = [dcmread(dicom) for dicom in filepaths]
             snr_dcm2 = ACRObject(data2).slice_stack[6]

--- a/hazenlib/tasks/acr_snr.py
+++ b/hazenlib/tasks/acr_snr.py
@@ -32,6 +32,7 @@ from typing import Any
 
 # Module imports
 import numpy as np
+from hazenlib.utils import get_dicom_files
 from scipy import ndimage
 
 # Local imports
@@ -130,15 +131,8 @@ class ACRSNR(HazenTask):
                 traceback.print_exc(file=sys.stdout)
         # SUBTRACTION METHOD
         else:
-            # Get the absolute path to all FILES found in the directory provided
-            filepaths = [
-                os.path.join(self.subtract, f)
-                for f in os.listdir(self.subtract)
-                if (
-                    os.path.isfile(os.path.join(self.subtract, f))
-                    and ".DS_Store" not in f
-                )
-            ]
+            # Use the shared helper to get all DICOM files from the directory provided
+            filepaths = get_dicom_files(Path(self.subtract))
             data2 = [dcmread(dicom) for dicom in filepaths]
             snr_dcm2 = ACRObject(data2).slice_stack[6]
 

--- a/hazenlib/tasks/acr_uniformity.py
+++ b/hazenlib/tasks/acr_uniformity.py
@@ -50,8 +50,9 @@ class ACRUniformity(HazenTask):
         # Initialise ACR object
         self.ACR_obj = ACRObject(self.dcm_list)
         # Required pixel radius to produce ~200cm2 ROI
+        # (this produces 25000 mm2??)
         self.r_large = compute_radius_from_area(200, self.ACR_obj.dx)
-        # Required pixel radius to produce ~1cm2 ROI
+        # Required pixel radius to produce ~1cm2 ROI (produces 150mm2)
         self.r_small = compute_radius_from_area(1, self.ACR_obj.dx)
         # Kernel we can use to convolve on input array to obtain an ROI mean
         self.r_small_kernel = create_circular_mean_kernel(self.r_small)

--- a/uv.lock
+++ b/uv.lock
@@ -344,7 +344,7 @@ wheels = [
 
 [[package]]
 name = "hazen"
-version = "2.0.0a3"
+version = "2.0.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "colorlog" },


### PR DESCRIPTION
The .DS_Store files were being included in the list of files to be processed, causing errors. This commit fixes the issue by excluding .DS_Store files from the list.

Re-implementation of #503 originally by @rs-sprout98

Refs: #503