### PR TITLE
Fix uniformity plot bug where x and y coordinates were swapped

### DIFF
--- a/hazenlib/tasks/acr_uniformity.py
+++ b/hazenlib/tasks/acr_uniformity.py
@@ -103,6 +103,11 @@ class ACRUniformity(HazenTask):
         return results
 
     def write_report(self, img, centre, min_roi, max_roi, piu, dcm):
+        # To keep convention with the rest of this module
+        # we'll unpack these variables x, y
+        # with the note that x = rows and y = columns
+        # which is different to the usual convention
+        # of x = columns and y = rows.
         (centre_x, centre_y) = centre
         x_max, y_max, max_value = max_roi
         x_min, y_min, min_value = min_roi
@@ -119,26 +124,26 @@ class ACRUniformity(HazenTask):
         axes[0].set_title("Centroid Location")
 
         axes[1].imshow(img)
-        axes[1].scatter([y_max, y_min], [x_max, x_min], c="red", marker="x")
+        axes[1].scatter([x_max, x_min], [y_max, y_min], c="red", marker="x")
         axes[1].plot(
-            self.r_small * np.cos(theta) + y_max,
             self.r_small * np.sin(theta) + x_max,
+            self.r_small * np.cos(theta) + y_max,
             c="yellow",
         )
         axes[1].annotate(
             "Min = " + str(np.round(min_value, 1)),
-            [y_min, x_min + self.label_x_offset],
+            [x_min + self.label_x_offset, y_min],
             c="white",
         )
 
         axes[1].plot(
-            self.r_small * np.cos(theta) + y_min,
             self.r_small * np.sin(theta) + x_min,
+            self.r_small * np.cos(theta) + y_min,
             c="yellow",
         )
         axes[1].annotate(
             "Max = " + str(np.round(max_value, 1)),
-            [y_max, x_max + self.label_x_offset],
+            [x_max + self.label_x_offset, y_max],
             c="white",
         )
         axes[1].plot(

--- a/hazenlib/tasks/acr_uniformity.py
+++ b/hazenlib/tasks/acr_uniformity.py
@@ -103,12 +103,13 @@ class ACRUniformity(HazenTask):
         return results
 
     def write_report(self, img, centre, min_roi, max_roi, piu, dcm):
+        (centre_x, centre_y) = centre
+
         # To keep convention with the rest of this module
         # we'll unpack these variables x, y
         # with the note that x = rows and y = columns
         # which is different to the usual convention
         # of x = columns and y = rows.
-        (centre_x, centre_y) = centre
         x_max, y_max, max_value = max_roi
         x_min, y_min, min_value = min_roi
 
@@ -119,7 +120,7 @@ class ACRUniformity(HazenTask):
         theta = np.linspace(0, 2 * np.pi, 360)
 
         axes[0].imshow(img)
-        axes[0].scatter(centre_x, centre_y, c="red")
+        axes[0].scatter(centre_y, centre_x, c="red")
         axes[0].axis("off")
         axes[0].set_title("Centroid Location")
 

--- a/tests/test_acr_uniformity.py
+++ b/tests/test_acr_uniformity.py
@@ -33,7 +33,7 @@ class TestACRUniformitySiemens(unittest.TestCase):
         (
             (center_x, center_y),
             _,
-        )= self.acr_uniformity_task.ACR_obj.find_phantom_center(
+        ) = self.acr_uniformity_task.ACR_obj.find_phantom_center(
             img,
             self.acr_uniformity_task.ACR_obj.dx,
             self.acr_uniformity_task.ACR_obj.dy,
@@ -65,7 +65,7 @@ class TestACRUniformitySiemens(unittest.TestCase):
             ~large_roi_valid_space,
         )
 
-        for (x, y) in ([x_min, y_min], [x_max, y_max]):
+        for x, y in ([x_min, y_min], [x_max, y_max]):
             dist_from_center = (
                 np.sqrt((x - center_x) ** 2 + (y - center_y) ** 2)
                 + self.acr_uniformity_task.r_small
@@ -86,6 +86,7 @@ class TestACRUniformitySiemens(unittest.TestCase):
         print("fixed_values:", self.piu)
 
         assert rounded_results == self.piu
+
 
 class TestACRUniformityGESignaArtistT1(TestACRUniformitySiemens):
     ACR_DATA = pathlib.Path(TEST_DATA_DIR) / "acr" / "GE_Signa_Artist_1.5T_T1"

--- a/tests/test_acr_uniformity.py
+++ b/tests/test_acr_uniformity.py
@@ -1,7 +1,16 @@
+# Python imports
 import unittest
 import pathlib
 
-from hazenlib.utils import get_dicom_files
+# Module imports
+import numpy as np
+
+# Local imports
+from hazenlib.utils import (
+    get_dicom_files,
+    create_circular_mask,
+    create_circular_roi_at,
+)
 from hazenlib.tasks.acr_uniformity import ACRUniformity
 from tests import TEST_DATA_DIR, TEST_REPORT_DIR
 
@@ -18,6 +27,54 @@ class TestACRUniformitySiemens(unittest.TestCase):
             report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR),
         )
 
+    def test_roi_values_within_roi(self) -> None:
+        """Test the ROI values actually lie within the ROI."""
+        img = self.acr_uniformity_task.ACR_obj.slice_stack[6].pixel_array
+        (
+            (center_x, center_y),
+            _,
+        )= self.acr_uniformity_task.ACR_obj.find_phantom_center(
+            img,
+            self.acr_uniformity_task.ACR_obj.dx,
+            self.acr_uniformity_task.ACR_obj.dy,
+        )
+
+        large_roi = create_circular_roi_at(
+            img,
+            self.acr_uniformity_task.r_large,
+            center_x,
+            center_y,
+        )
+
+        large_roi_valid_space = create_circular_mask(
+            img,
+            self.acr_uniformity_task.r_large_filter,
+            center_x,
+            center_y,
+        )
+
+        (
+            x_min,
+            y_min,
+            _,
+            x_max,
+            y_max,
+            _,
+        ) = self.acr_uniformity_task.get_mean_roi_values(
+            large_roi,
+            ~large_roi_valid_space,
+        )
+
+        for (x, y) in ([x_min, y_min], [x_max, y_max]):
+            dist_from_center = (
+                np.sqrt((x - center_x) ** 2 + (y - center_y) ** 2)
+                + self.acr_uniformity_task.r_small
+            )
+            self.assertLessEqual(
+                dist_from_center,
+                self.acr_uniformity_task.r_large,
+            )
+
     def test_uniformity(self):
         results = self.acr_uniformity_task.get_integral_uniformity(
             self.acr_uniformity_task.ACR_obj.slice_stack[6]
@@ -30,55 +87,19 @@ class TestACRUniformitySiemens(unittest.TestCase):
 
         assert rounded_results == self.piu
 
+class TestACRUniformityGESignaArtistT1(TestACRUniformitySiemens):
+    ACR_DATA = pathlib.Path(TEST_DATA_DIR) / "acr" / "GE_Signa_Artist_1.5T_T1"
+    piu = 92.03
 
-class TestACRUniformitySiemensSolaFit(unittest.TestCase):
+
+class TestACRUniformitySiemensSolaFit(TestACRUniformitySiemens):
     ACR_DATA = pathlib.Path(TEST_DATA_DIR / "acr" / "SiemensSolaFit")
     piu = 95.77
 
-    def setUp(self):
-        input_files = get_dicom_files(self.ACR_DATA)
 
-        self.acr_uniformity_task = ACRUniformity(
-            input_data=input_files,
-            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR),
-        )
-
-    def test_uniformity(self):
-        results = self.acr_uniformity_task.get_integral_uniformity(
-            self.acr_uniformity_task.ACR_obj.slice_stack[6]
-        )
-        rounded_results = round(results, 2)
-
-        print("\ntest_uniformity.py::TestUniformity::test_uniformity")
-        print("new_release_values:", rounded_results)
-        print("fixed_values:", self.piu)
-
-        assert rounded_results == self.piu
-
-
-class TestACRUniformityPhilipsAchieva(unittest.TestCase):
+class TestACRUniformityPhilipsAchieva(TestACRUniformitySiemens):
     ACR_DATA = pathlib.Path(TEST_DATA_DIR / "acr" / "PhilipsAchieva")
     piu = 80.66
-
-    def setUp(self):
-        input_files = get_dicom_files(self.ACR_DATA)
-
-        self.acr_uniformity_task = ACRUniformity(
-            input_data=input_files,
-            report_dir=pathlib.PurePath.joinpath(TEST_REPORT_DIR),
-        )
-
-    def test_uniformity(self):
-        results = self.acr_uniformity_task.get_integral_uniformity(
-            self.acr_uniformity_task.ACR_obj.slice_stack[6]
-        )
-        rounded_results = round(results, 2)
-
-        print("\ntest_uniformity.py::TestUniformity::test_uniformity")
-        print("new_release_values:", rounded_results)
-        print("fixed_values:", self.piu)
-
-        assert rounded_results == self.piu
 
 
 class TestACRUniformityGE(TestACRUniformitySiemens):

--- a/uv.lock
+++ b/uv.lock
@@ -344,7 +344,7 @@ wheels = [
 
 [[package]]
 name = "hazen"
-version = "2.0.0a4"
+version = "2.0.0a5"
 source = { editable = "." }
 dependencies = [
     { name = "colorlog" },


### PR DESCRIPTION
- Closes #508 
- Added tests to ensure that uniformity coordinates + radius are fully contained in the ROI.
- Swapped incorrect coordinates.