### PR TITLE
feat(orchestration): automatically set report=True for all or intermdiate levels

### DIFF
--- a/hazenlib/orchestration.py
+++ b/hazenlib/orchestration.py
@@ -531,7 +531,12 @@ class BatchConfig:
 
         data["report_template"] = resolve_path_as_posix(self.report_template)
 
-        data["defaults"] = self.defaults
+        data["defaults"] = {} if self.defaults is None else self.defaults
+
+        data["defaults"]["report"] = self._check_and_set_default_report(
+            data["levels"],
+            report=data["defaults"].get("report", False),
+        )
 
         # Build jobs list
         jobs_data: list[dict[str, Any]] = []
@@ -727,6 +732,21 @@ class BatchConfig:
             )
             raise RuntimeError(msg)
 
+    @staticmethod
+    def _check_and_set_default_report(
+        levels: list[str],
+        *,
+        report: bool,
+    ) -> bool:
+        if "all" in levels or "intermediate" in levels:
+            logger.info(
+                "levels = %s requires report=True as a default"
+                " so this has been set.",
+                levels,
+            )
+            return True
+        return report
+
     @classmethod
     def from_config(
         cls,
@@ -794,6 +814,12 @@ class BatchConfig:
         levels = data.get("levels", ["final"])
         if isinstance(levels, str):
             levels = [levels]
+
+        defaults = data.get("defaults", {})
+        defaults["report"] = cls._check_and_set_default_report(
+            levels,
+            report=defaults.get("report", False),
+        )
         return cls(
             version=data.get("version", "1.0"),
             hazen_version_constraint=data.get("hazen_version_constraint"),
@@ -803,7 +829,7 @@ class BatchConfig:
             levels=levels,
             report_docx=report_docx,
             report_template=report_template,
-            defaults=data.get("defaults", {}),
+            defaults=defaults,
             _file=config_path,
             _dry_run=dry_run,
         )

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -968,7 +968,7 @@ class TestBatchConfig(unittest.TestCase):
         self.assertEqual(config.description, "")  # default
         self.assertEqual(config.levels, ["final"])  # default
         self.assertIsNone(config.report_docx)  # default
-        self.assertEqual(config.defaults, {})  # default
+        self.assertEqual(config.defaults, {"report": False})  # default
 
     @patch("pathlib.Path.open", mock_open(read_data="{}"))
     @patch("yaml.safe_load")
@@ -1130,7 +1130,10 @@ class TestBatchConfigToYaml(unittest.TestCase):
         self.assertIsNone(data["hazen_version_constraint"])
         self.assertIsNone(data["report_docx"])
         self.assertIsNone(data["report_template"])
-        self.assertIsNone(data["defaults"])
+
+        # Report is automatically set based on level.
+        # levels=None => levels=("final", "all") => report=True
+        self.assertEqual(data["defaults"], {"report": True})
 
     @patch.dict(TASK_REGISTRY, {"test_task": Mock()}, clear=False)
     @patch("pathlib.Path.exists")


### PR DESCRIPTION
Add `_check_and_set_default_report` method to enforce report generation when processing "all" or "intermediate" levels. Updates `to_yaml` and `from_config` to apply this logic, ensuring reports are enabled by default for levels that require intermediate output.