### PR TITLE
fix: improve slice order notification message when no circle detected

### DIFF
--- a/hazenlib/ACRObject.py
+++ b/hazenlib/ACRObject.py
@@ -199,7 +199,7 @@ class ACRObject:
             logger.info("Performing slice order inversion.")
             return dcm_list[::-1]
 
-        logger.debug("Neither slices had a circle detected")
+        logger.warning("Neither first nor last slice had a circle detected. Slice order cannot be verified - returning slices in original order.")
         return dcm_list
 
     @staticmethod


### PR DESCRIPTION
This PR improves the notification message in the order_phantom_slices 
function in ACRObject.py.

Previously, when neither the first nor last slice had a circle detected, 
the code used a vague debug message that gave no useful information to 
the user.

This fix changes it to a clear warning message explaining that slice 
order cannot be verified and that slices are returned in their original 
order.

Relates to issue #439